### PR TITLE
Update one-click-installer for Windows

### DIFF
--- a/INSTRUCTIONS.txt
+++ b/INSTRUCTIONS.txt
@@ -2,7 +2,7 @@ Thank you for downloading oobabooga/text-generation-webui.
 Here is how to get it up and running:
 
 1. Run the "install" script to install the web UI and its requirements in this folder.
-2. Run the "download" script to download a model of your choice.
+2. Run the "download" script to download a model of your choice. Change TextOnly variable at top of script to download only config files.
 3. Run the "start-webui" script to launch the web UI.
 
 To add flags like --chat, --notebook, --extensions, etc, edit the

--- a/download-model.bat
+++ b/download-model.bat
@@ -7,11 +7,10 @@ cd /D "%~dp0"
 set MAMBA_ROOT_PREFIX=%cd%\installer_files\mamba
 set INSTALL_ENV_DIR=%cd%\installer_files\env
 
-if not exist "%MAMBA_ROOT_PREFIX%\Scripts\activate.bat" (
+if not exist "%MAMBA_ROOT_PREFIX%\condabin\micromamba.bat" (
   call "%MAMBA_ROOT_PREFIX%\micromamba.exe" shell hook >nul 2>&1
 )
-call "%MAMBA_ROOT_PREFIX%\condabin\mamba_hook.bat" || ( echo MicroMamba hook not found. && goto end )
-call micromamba activate "%INSTALL_ENV_DIR%" || goto end
+call "%MAMBA_ROOT_PREFIX%\condabin\micromamba.bat" activate "%INSTALL_ENV_DIR%" || ( echo MicroMamba hook not found. && goto end )
 
 cd text-generation-webui || goto end
 goto %TextOnly%

--- a/download-model.bat
+++ b/download-model.bat
@@ -1,9 +1,28 @@
 @echo off
 
-set INSTALL_ENV_DIR=%cd%\installer_files\env
-set PATH=%INSTALL_ENV_DIR%;%INSTALL_ENV_DIR%\Library\bin;%INSTALL_ENV_DIR%\Scripts;%INSTALL_ENV_DIR%\Library\usr\bin;%PATH%
-call conda activate
-cd text-generation-webui
-python download-model.py
+SET TextOnly=False &REM True or False for Text only mode
+SET ModelName="chansung/alpaca-lora-13b" &REM HuggingFace model repo eg. "facebook/opt-1.3b"
 
+cd /D "%~dp0"
+
+set MAMBA_ROOT_PREFIX=%cd%\installer_files\mamba
+set INSTALL_ENV_DIR=%cd%\installer_files\env
+
+if not exist "%MAMBA_ROOT_PREFIX%\Scripts\activate.bat" (
+  call "%MAMBA_ROOT_PREFIX%\micromamba.exe" shell hook >nul 2>&1
+)
+call "%MAMBA_ROOT_PREFIX%\condabin\mamba_hook.bat" || ( echo MicroMamba hook not found. && goto end )
+call micromamba activate "%INSTALL_ENV_DIR%" || goto end
+
+cd text-generation-webui || goto end
+goto %TextOnly%
+
+:False
+call python download-model.py %ModelName%
+goto end
+
+:True
+call python download-model.py %ModelName% --text-only
+
+:end
 pause

--- a/download-model.bat
+++ b/download-model.bat
@@ -1,7 +1,6 @@
 @echo off
 
 SET TextOnly=False &REM True or False for Text only mode
-SET ModelName="chansung/alpaca-lora-13b" &REM HuggingFace model repo eg. "facebook/opt-1.3b"
 
 cd /D "%~dp0"
 
@@ -18,11 +17,11 @@ cd text-generation-webui || goto end
 goto %TextOnly%
 
 :False
-call python download-model.py %ModelName%
+call python download-model.py
 goto end
 
 :True
-call python download-model.py %ModelName% --text-only
+call python download-model.py --text-only
 
 :end
 pause

--- a/install.bat
+++ b/install.bat
@@ -53,24 +53,19 @@ if "%PACKAGES_TO_INSTALL%" NEQ "" (
     )
 
     @rem create micromamba hook
-    if not exist "%MAMBA_ROOT_PREFIX%\condabin\mamba_hook.bat" (
+    if not exist "%MAMBA_ROOT_PREFIX%\condabin\micromamba.bat" (
       call "%MAMBA_ROOT_PREFIX%\micromamba.exe" shell hook >nul 2>&1
     )
 
-    @rem activate base micromamba env
-    call "%MAMBA_ROOT_PREFIX%\condabin\mamba_hook.bat" || ( echo Micromamba hook not found. && goto end )
-
     @rem create the installer env
     if not exist "%INSTALL_ENV_DIR%" (
-        call micromamba create -y --prefix "%INSTALL_ENV_DIR%"
+      echo Packages to install: %PACKAGES_TO_INSTALL%
+      call "%MAMBA_ROOT_PREFIX%\micromamba.exe" create -y --prefix "%INSTALL_ENV_DIR%" %CHANNEL% %PACKAGES_TO_INSTALL%
     )
-    @rem activate installer env
-    call micromamba activate "%INSTALL_ENV_DIR%" || ( echo %INSTALL_ENV_DIR% not found. && goto end )
-
-    echo "Packages to install: %PACKAGES_TO_INSTALL%"
-
-    call micromamba install -y %CHANNEL% %PACKAGES_TO_INSTALL%
 )
+
+@rem activate installer env
+call "%MAMBA_ROOT_PREFIX%\condabin\micromamba.bat" activate "%INSTALL_ENV_DIR%" || ( echo MicroMamba hook not found. && goto end )
 
 @rem clone the repository and install the pip requirements
 if exist text-generation-webui\ (

--- a/install.bat
+++ b/install.bat
@@ -111,7 +111,7 @@ mv libbitsandbytes_cpu.dll "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes"
 mv libbitsandbytes_cudaall.dll "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes"
 sed -i "s/if not torch.cuda.is_available(): return 'libsbitsandbytes_cpu.so', None, None, None, None/if torch.cuda.is_available(): return 'libbitsandbytes_cudaall.dll', None, None, None, None\n    else: return 'libbitsandbytes_cpu.dll', None, None, None, None/g" "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes\cuda_setup\main.py"
 sed -i "s/ct.cdll.LoadLibrary(binary_path)/ct.cdll.LoadLibrary(str(binary_path))/g" "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes\cuda_setup\main.py"
-sed -i "s/make_quant(model, layers, wbits, groupsize, faster=args.faster_kernel)/make_quant(model, layers, wbits, groupsize)/g" "%INSTALL_ENV_DIR%\..\..\text-generation-webui\repositories\GPTQ-for-LLaMa\llama.py"
+sed -i "s/make_quant(model, layers, wbits, groupsize, faster=args.faster_kernel)/make_quant(model, layers, wbits, groupsize, faster=("args" in globals() and args.faster_kernel))/g" "%INSTALL_ENV_DIR%\..\..\text-generation-webui\repositories\GPTQ-for-LLaMa\llama.py"
 
 :end
 pause

--- a/install.bat
+++ b/install.bat
@@ -94,14 +94,14 @@ if not exist GPTQ-for-LLaMa\ (
   git clone https://github.com/qwopqwop200/GPTQ-for-LLaMa.git
   cd GPTQ-for-LLaMa || goto end
   git reset --hard 468c47c01b4fe370616747b6d69a2d3f48bab5e4
-  pip install -r requirements.txt
+  call python -m pip install -r requirements.txt
   call python setup_cuda.py install
   if not exist "%INSTALL_ENV_DIR%\lib\site-packages\quant_cuda-0.0.0-py3.10-win-amd64.egg" (
     echo CUDA kernal compilation failed. Will try to install from wheel.
-    pip install unzip
+    call python -m pip install unzip
     curl -LO https://github.com/oobabooga/text-generation-webui/files/11023775/quant_cuda-0.0.0-cp310-cp310-win_amd64.whl.zip
     unzip quant_cuda-0.0.0-cp310-cp310-win_amd64.whl.zip
-    pip install quant_cuda-0.0.0-cp310-cp310-win_amd64.whl || ( echo Wheel installation failed. && goto end )
+    call python -m pip install quant_cuda-0.0.0-cp310-cp310-win_amd64.whl || ( echo Wheel installation failed. && goto end )
   )
   cd ..
 )
@@ -112,7 +112,6 @@ curl -LO https://github.com/DeXtmL/bitsandbytes-win-prebuilt/raw/main/libbitsand
 curl -LO https://github.com/james-things/bitsandbytes-prebuilt-all_arch/raw/main/0.37.0/libbitsandbytes_cudaall.dll
 mv libbitsandbytes_cpu.dll "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes"
 mv libbitsandbytes_cudaall.dll "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes"
-pip install sed
 sed -i "s/if not torch.cuda.is_available(): return 'libsbitsandbytes_cpu.so', None, None, None, None/if torch.cuda.is_available(): return 'libbitsandbytes_cudaall.dll', None, None, None, None\n    else: return 'libbitsandbytes_cpu.dll', None, None, None, None/g" "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes\cuda_setup\main.py"
 sed -i "s/ct.cdll.LoadLibrary(binary_path)/ct.cdll.LoadLibrary(str(binary_path))/g" "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes\cuda_setup\main.py"
 

--- a/install.bat
+++ b/install.bat
@@ -114,6 +114,7 @@ mv libbitsandbytes_cpu.dll "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes"
 mv libbitsandbytes_cudaall.dll "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes"
 sed -i "s/if not torch.cuda.is_available(): return 'libsbitsandbytes_cpu.so', None, None, None, None/if torch.cuda.is_available(): return 'libbitsandbytes_cudaall.dll', None, None, None, None\n    else: return 'libbitsandbytes_cpu.dll', None, None, None, None/g" "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes\cuda_setup\main.py"
 sed -i "s/ct.cdll.LoadLibrary(binary_path)/ct.cdll.LoadLibrary(str(binary_path))/g" "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes\cuda_setup\main.py"
+sed -i "s/make_quant(model, layers, wbits, groupsize, faster=args.faster_kernel)/make_quant(model, layers, wbits, groupsize)/g" "%INSTALL_ENV_DIR%\..\..\text-generation-webui\repositories\GPTQ-for-LLaMa\llama.py"
 
 :end
 pause

--- a/install.bat
+++ b/install.bat
@@ -111,7 +111,6 @@ mv libbitsandbytes_cpu.dll "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes"
 mv libbitsandbytes_cudaall.dll "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes"
 sed -i "s/if not torch.cuda.is_available(): return 'libsbitsandbytes_cpu.so', None, None, None, None/if torch.cuda.is_available(): return 'libbitsandbytes_cudaall.dll', None, None, None, None\n    else: return 'libbitsandbytes_cpu.dll', None, None, None, None/g" "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes\cuda_setup\main.py"
 sed -i "s/ct.cdll.LoadLibrary(binary_path)/ct.cdll.LoadLibrary(str(binary_path))/g" "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes\cuda_setup\main.py"
-sed -i "s/make_quant(model, layers, wbits, groupsize, faster=args.faster_kernel)/make_quant(model, layers, wbits, groupsize, faster=("args" in globals() and args.faster_kernel))/g" "%INSTALL_ENV_DIR%\..\..\text-generation-webui\repositories\GPTQ-for-LLaMa\llama.py"
 
 :end
 pause

--- a/install.bat
+++ b/install.bat
@@ -26,6 +26,8 @@ if /I "%gpuchoice%" == "A" (
 
 cd /D "%~dp0"
 
+set PATH=%SystemRoot%\system32;%PATH%
+
 set MAMBA_ROOT_PREFIX=%cd%\installer_files\mamba
 set INSTALL_ENV_DIR=%cd%\installer_files\env
 set MICROMAMBA_DOWNLOAD_URL=https://github.com/cmdr2/stable-diffusion-ui/releases/download/v1.1/micromamba.exe

--- a/install.bat
+++ b/install.bat
@@ -30,7 +30,7 @@ set PATH=%SystemRoot%\system32;%PATH%
 
 set MAMBA_ROOT_PREFIX=%cd%\installer_files\mamba
 set INSTALL_ENV_DIR=%cd%\installer_files\env
-set MICROMAMBA_DOWNLOAD_URL=https://github.com/cmdr2/stable-diffusion-ui/releases/download/v1.1/micromamba.exe
+set MICROMAMBA_DOWNLOAD_URL=https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-win-64
 set REPO_URL=https://github.com/oobabooga/text-generation-webui.git
 set umamba_exists=F
 

--- a/install.bat
+++ b/install.bat
@@ -24,6 +24,8 @@ if /I "%gpuchoice%" == "A" (
     exit
 )
 
+cd /D "%~dp0"
+
 set MAMBA_ROOT_PREFIX=%cd%\installer_files\mamba
 set INSTALL_ENV_DIR=%cd%\installer_files\env
 set MICROMAMBA_DOWNLOAD_URL=https://github.com/cmdr2/stable-diffusion-ui/releases/download/v1.1/micromamba.exe

--- a/install.bat
+++ b/install.bat
@@ -1,7 +1,7 @@
 @echo off
 
 @rem Based on the installer found here: https://github.com/Sygil-Dev/sygil-webui
-@rem This script will install git and conda (if not found on the PATH variable)
+@rem This script will install git and all dependencies
 @rem using micromamba (an 8mb static-linked single-file binary, conda replacement).
 @rem This enables a user to install this project without manually installing conda and git.
 
@@ -12,16 +12,13 @@ echo B) None (I want to run in CPU mode)
 echo.
 set /p "gpuchoice=Input> "
 set gpuchoice=%gpuchoice:~0,1%
-setlocal enabledelayedexpansion
-set gpuchoice=!gpuchoice:a=A!
-set gpuchoice=!gpuchoice:b=B!
 
-if "%gpuchoice%" == "A" (
-    set "PACKAGES_TO_INSTALL=torchvision=0.14.1 torchaudio=0.13.1 pytorch-cuda=11.7 conda git"
-    set "CHANNEL=-c nvidia"
-) else if "%gpuchoice%" == "B" (
-    set "PACKAGES_TO_INSTALL=pytorch torchvision torchaudio cpuonly conda git"
-    set "CHANNEL="
+if /I "%gpuchoice%" == "A" (
+    set "PACKAGES_TO_INSTALL=python=3.10.9 pytorch torchvision torchaudio pytorch-cuda=11.7 cuda-toolkit conda-forge::ninja conda-forge::git"
+    set "CHANNEL=-c pytorch -c nvidia/label/cuda-11.7.0 -c nvidia"
+) else if /I "%gpuchoice%" == "B" (
+    set "PACKAGES_TO_INSTALL=pytorch torchvision torchaudio cpuonly git"
+    set "CHANNEL=-c conda-forge -c pytorch"
 ) else (
     echo Invalid choice. Exiting...
     exit
@@ -34,57 +31,91 @@ set REPO_URL=https://github.com/oobabooga/text-generation-webui.git
 set umamba_exists=F
 
 @rem figure out whether git and conda needs to be installed
-if exist "%INSTALL_ENV_DIR%" set PATH=%INSTALL_ENV_DIR%;%INSTALL_ENV_DIR%\Library\bin;%INSTALL_ENV_DIR%\Scripts;%INSTALL_ENV_DIR%\Library\usr\bin;%PATH%
-call "%MAMBA_ROOT_PREFIX%\micromamba.exe" --version >.tmp1 2>.tmp2
+call "%MAMBA_ROOT_PREFIX%\micromamba.exe" --version >nul 2>&1
 if "%ERRORLEVEL%" EQU "0" set umamba_exists=T
 
 @rem (if necessary) install git and conda into a contained environment
 if "%PACKAGES_TO_INSTALL%" NEQ "" (
     @rem download micromamba
     if "%umamba_exists%" == "F" (
-        echo "Downloading micromamba from %MICROMAMBA_DOWNLOAD_URL% to %MAMBA_ROOT_PREFIX%\micromamba.exe"
+        echo "Downloading Micromamba from %MICROMAMBA_DOWNLOAD_URL% to %MAMBA_ROOT_PREFIX%\micromamba.exe"
 
         mkdir "%MAMBA_ROOT_PREFIX%"
         call curl -L "%MICROMAMBA_DOWNLOAD_URL%" > "%MAMBA_ROOT_PREFIX%\micromamba.exe"
 
         @rem test the mamba binary
         echo Micromamba version:
-        call "%MAMBA_ROOT_PREFIX%\micromamba.exe" --version
+        call "%MAMBA_ROOT_PREFIX%\micromamba.exe" --version || ( echo Micromamba not found. && goto end )
     )
+
+    @rem create micromamba hook
+    if not exist "%MAMBA_ROOT_PREFIX%\condabin\mamba_hook.bat" (
+      call "%MAMBA_ROOT_PREFIX%\micromamba.exe" shell hook >nul 2>&1
+    )
+
+    @rem activate base micromamba env
+    call "%MAMBA_ROOT_PREFIX%\condabin\mamba_hook.bat" || ( echo Micromamba hook not found. && goto end )
 
     @rem create the installer env
     if not exist "%INSTALL_ENV_DIR%" (
-        call "%MAMBA_ROOT_PREFIX%\micromamba.exe" create -y --prefix "%INSTALL_ENV_DIR%"
+        call micromamba create -y --prefix "%INSTALL_ENV_DIR%"
     )
+    @rem activate installer env
+    call micromamba activate "%INSTALL_ENV_DIR%" || ( echo %INSTALL_ENV_DIR% not found. && goto end )
 
     echo "Packages to install: %PACKAGES_TO_INSTALL%"
 
-    call "%MAMBA_ROOT_PREFIX%\micromamba.exe" install -y --prefix "%INSTALL_ENV_DIR%" -c conda-forge -c pytorch %CHANNEL% %PACKAGES_TO_INSTALL%
-    call "%MAMBA_ROOT_PREFIX%\micromamba.exe" install -y --prefix "%INSTALL_ENV_DIR%" -c conda-forge -c pytorch %CHANNEL% %PACKAGES_TO_INSTALL%
-
-    if not exist "%INSTALL_ENV_DIR%" (
-        echo "There was a problem while installing%PACKAGES_TO_INSTALL% using micromamba. Cannot continue."
-        pause
-        exit /b
-    )
+    call micromamba install -y %CHANNEL% %PACKAGES_TO_INSTALL%
 )
 
-set PATH=%INSTALL_ENV_DIR%;%INSTALL_ENV_DIR%\Library\bin;%INSTALL_ENV_DIR%\Scripts;%INSTALL_ENV_DIR%\Library\usr\bin;%PATH%
-
 @rem clone the repository and install the pip requirements
-call conda activate
 if exist text-generation-webui\ (
   cd text-generation-webui
   git pull
 ) else (
   git clone https://github.com/oobabooga/text-generation-webui.git
-  cd text-generation-webui
+  cd text-generation-webui || goto end
 )
 call python -m pip install -r requirements.txt --upgrade
-call python -m pip install -r extensions\google_translate\requirements.txt
-call python -m pip install -r extensions\silero_tts\requirements.txt
+call python -m pip install -r extensions\api\requirements.txt --upgrade
+call python -m pip install -r extensions\elevenlabs_tts\requirements.txt --upgrade
+call python -m pip install -r extensions\google_translate\requirements.txt --upgrade
+call python -m pip install -r extensions\silero_tts\requirements.txt --upgrade
+call python -m pip install -r extensions\whisper_stt\requirements.txt --upgrade
 
-cd ..
-del .tmp1 .tmp2
+@rem skip gptq install if cpu only
+if /I not "%gpuchoice%" == "A" goto bandaid
 
+@rem download gptq and compile locally and if compile fails, install from wheel
+if not exist repositories\ (
+  mkdir repositories
+)
+cd repositories || goto end
+if not exist GPTQ-for-LLaMa\ (
+  git clone https://github.com/qwopqwop200/GPTQ-for-LLaMa.git
+  cd GPTQ-for-LLaMa || goto end
+  git reset --hard 468c47c01b4fe370616747b6d69a2d3f48bab5e4
+  pip install -r requirements.txt
+  call python setup_cuda.py install
+  if not exist "%INSTALL_ENV_DIR%\lib\site-packages\quant_cuda-0.0.0-py3.10-win-amd64.egg" (
+    echo CUDA kernal compilation failed. Will try to install from wheel.
+    pip install unzip
+    curl -LO https://github.com/oobabooga/text-generation-webui/files/11023775/quant_cuda-0.0.0-cp310-cp310-win_amd64.whl.zip
+    unzip quant_cuda-0.0.0-cp310-cp310-win_amd64.whl.zip
+    pip install quant_cuda-0.0.0-cp310-cp310-win_amd64.whl || ( echo Wheel installation failed. && goto end )
+  )
+  cd ..
+)
+cd ..\..
+
+:bandaid
+curl -LO https://github.com/DeXtmL/bitsandbytes-win-prebuilt/raw/main/libbitsandbytes_cpu.dll
+curl -LO https://github.com/james-things/bitsandbytes-prebuilt-all_arch/raw/main/0.37.0/libbitsandbytes_cudaall.dll
+mv libbitsandbytes_cpu.dll "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes"
+mv libbitsandbytes_cuda116.dll "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes"
+pip install sed
+sed -i "s/if not torch.cuda.is_available(): return 'libsbitsandbytes_cpu.so', None, None, None, None/if torch.cuda.is_available(): return 'libbitsandbytes_cudaall.dll', None, None, None, None\n    else: return 'libbitsandbytes_cpu.dll', None, None, None, None/g" "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes\cuda_setup\main.py"
+sed -i "s/ct.cdll.LoadLibrary(binary_path)/ct.cdll.LoadLibrary(str(binary_path))/g" "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes\cuda_setup\main.py"
+
+:end
 pause

--- a/install.bat
+++ b/install.bat
@@ -93,14 +93,11 @@ cd repositories || goto end
 if not exist GPTQ-for-LLaMa\ (
   git clone https://github.com/qwopqwop200/GPTQ-for-LLaMa.git
   cd GPTQ-for-LLaMa || goto end
-  git reset --hard 468c47c01b4fe370616747b6d69a2d3f48bab5e4
   call python -m pip install -r requirements.txt
   call python setup_cuda.py install
   if not exist "%INSTALL_ENV_DIR%\lib\site-packages\quant_cuda-0.0.0-py3.10-win-amd64.egg" (
     echo CUDA kernal compilation failed. Will try to install from wheel.
-    call python -m pip install unzip
-    curl -LO https://github.com/oobabooga/text-generation-webui/files/11023775/quant_cuda-0.0.0-cp310-cp310-win_amd64.whl.zip
-    unzip quant_cuda-0.0.0-cp310-cp310-win_amd64.whl.zip
+    curl -LO https://github.com/jllllll/GPTQ-for-LLaMa-Wheels/raw/main/quant_cuda-0.0.0-cp310-cp310-win_amd64.whl
     call python -m pip install quant_cuda-0.0.0-cp310-cp310-win_amd64.whl || ( echo Wheel installation failed. && goto end )
   )
   cd ..

--- a/install.bat
+++ b/install.bat
@@ -114,7 +114,7 @@ cd ..\..
 curl -LO https://github.com/DeXtmL/bitsandbytes-win-prebuilt/raw/main/libbitsandbytes_cpu.dll
 curl -LO https://github.com/james-things/bitsandbytes-prebuilt-all_arch/raw/main/0.37.0/libbitsandbytes_cudaall.dll
 mv libbitsandbytes_cpu.dll "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes"
-mv libbitsandbytes_cuda116.dll "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes"
+mv libbitsandbytes_cudaall.dll "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes"
 pip install sed
 sed -i "s/if not torch.cuda.is_available(): return 'libsbitsandbytes_cpu.so', None, None, None, None/if torch.cuda.is_available(): return 'libbitsandbytes_cudaall.dll', None, None, None, None\n    else: return 'libbitsandbytes_cpu.dll', None, None, None, None/g" "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes\cuda_setup\main.py"
 sed -i "s/ct.cdll.LoadLibrary(binary_path)/ct.cdll.LoadLibrary(str(binary_path))/g" "%INSTALL_ENV_DIR%\lib\site-packages\bitsandbytes\cuda_setup\main.py"

--- a/install.bat
+++ b/install.bat
@@ -14,7 +14,7 @@ set /p "gpuchoice=Input> "
 set gpuchoice=%gpuchoice:~0,1%
 
 if /I "%gpuchoice%" == "A" (
-    set "PACKAGES_TO_INSTALL=python=3.10.9 pytorch torchvision torchaudio pytorch-cuda=11.7 cuda-toolkit conda-forge::ninja conda-forge::git"
+    set "PACKAGES_TO_INSTALL=python=3.10.9 torchvision torchaudio pytorch-cuda=11.7 cuda-toolkit conda-forge::ninja conda-forge::git"
     set "CHANNEL=-c pytorch -c nvidia/label/cuda-11.7.0 -c nvidia"
 ) else if /I "%gpuchoice%" == "B" (
     set "PACKAGES_TO_INSTALL=pytorch torchvision torchaudio cpuonly git"

--- a/micromamba-cmd.bat
+++ b/micromamba-cmd.bat
@@ -1,0 +1,15 @@
+@echo off
+
+set MAMBA_ROOT_PREFIX=%cd%\installer_files\mamba
+set INSTALL_ENV_DIR=%cd%\installer_files\env
+
+if not exist "%MAMBA_ROOT_PREFIX%\Scripts\activate.bat" (
+  call "%MAMBA_ROOT_PREFIX%\micromamba.exe" shell hook >nul 2>&1
+)
+call "%MAMBA_ROOT_PREFIX%\condabin\mamba_hook.bat" || ( echo Micromamba hook not found. && goto end )
+call micromamba activate "%INSTALL_ENV_DIR%" || goto end
+
+cmd /k "%*"
+
+:end
+pause

--- a/micromamba-cmd.bat
+++ b/micromamba-cmd.bat
@@ -5,11 +5,10 @@ cd /D "%~dp0"
 set MAMBA_ROOT_PREFIX=%cd%\installer_files\mamba
 set INSTALL_ENV_DIR=%cd%\installer_files\env
 
-if not exist "%MAMBA_ROOT_PREFIX%\Scripts\activate.bat" (
+if not exist "%MAMBA_ROOT_PREFIX%\condabin\micromamba.bat" (
   call "%MAMBA_ROOT_PREFIX%\micromamba.exe" shell hook >nul 2>&1
 )
-call "%MAMBA_ROOT_PREFIX%\condabin\mamba_hook.bat" || ( echo Micromamba hook not found. && goto end )
-call micromamba activate "%INSTALL_ENV_DIR%" || goto end
+call "%MAMBA_ROOT_PREFIX%\condabin\micromamba.bat" activate "%INSTALL_ENV_DIR%" || ( echo MicroMamba hook not found. && goto end )
 
 cmd /k "%*"
 

--- a/micromamba-cmd.bat
+++ b/micromamba-cmd.bat
@@ -1,5 +1,7 @@
 @echo off
 
+cd /D "%~dp0"
+
 set MAMBA_ROOT_PREFIX=%cd%\installer_files\mamba
 set INSTALL_ENV_DIR=%cd%\installer_files\env
 

--- a/start-webui.bat
+++ b/start-webui.bat
@@ -2,10 +2,19 @@
 
 @echo Starting the web UI...
 
+cd /D "%~dp0"
+
+set MAMBA_ROOT_PREFIX=%cd%\installer_files\mamba
 set INSTALL_ENV_DIR=%cd%\installer_files\env
-set PATH=%INSTALL_ENV_DIR%;%INSTALL_ENV_DIR%\Library\bin;%INSTALL_ENV_DIR%\Scripts;%INSTALL_ENV_DIR%\Library\usr\bin;%PATH%
-call conda activate
+
+if not exist "%MAMBA_ROOT_PREFIX%\Scripts\activate.bat" (
+  call "%MAMBA_ROOT_PREFIX%\micromamba.exe" shell hook >nul 2>&1
+)
+call "%MAMBA_ROOT_PREFIX%\condabin\mamba_hook.bat" || ( echo Micromamba hook not found. && goto end )
+call micromamba activate "%INSTALL_ENV_DIR%" || goto end
 cd text-generation-webui
+
 call python server.py --auto-devices --cai-chat
 
+:end
 pause

--- a/start-webui.bat
+++ b/start-webui.bat
@@ -7,11 +7,10 @@ cd /D "%~dp0"
 set MAMBA_ROOT_PREFIX=%cd%\installer_files\mamba
 set INSTALL_ENV_DIR=%cd%\installer_files\env
 
-if not exist "%MAMBA_ROOT_PREFIX%\Scripts\activate.bat" (
+if not exist "%MAMBA_ROOT_PREFIX%\condabin\micromamba.bat" (
   call "%MAMBA_ROOT_PREFIX%\micromamba.exe" shell hook >nul 2>&1
 )
-call "%MAMBA_ROOT_PREFIX%\condabin\mamba_hook.bat" || ( echo Micromamba hook not found. && goto end )
-call micromamba activate "%INSTALL_ENV_DIR%" || goto end
+call "%MAMBA_ROOT_PREFIX%\condabin\micromamba.bat" activate "%INSTALL_ENV_DIR%" || ( echo MicroMamba hook not found. && goto end )
 cd text-generation-webui
 
 call python server.py --auto-devices --cai-chat


### PR DESCRIPTION
Will allow automatic install and usage of the current webui using only Micromamba. May need more extensive testing as CMD is buggy and temperamental with file paths. It seems to work well enough for Windows 10 and 11: https://github.com/oobabooga/text-generation-webui/issues/520

Currently incorporates [oobabooga-one-click-bandaid](https://github.com/ClayShoaf/oobabooga-one-click-bandaid)