### PR TITLE
Change Micromamba download link

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -30,7 +30,7 @@ set PATH=%SystemRoot%\system32;%PATH%
 
 set MAMBA_ROOT_PREFIX=%cd%\installer_files\mamba
 set INSTALL_ENV_DIR=%cd%\installer_files\env
-set MICROMAMBA_DOWNLOAD_URL=https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-win-64
+set MICROMAMBA_DOWNLOAD_URL=https://github.com/mamba-org/micromamba-releases/releases/download/1.4.0-0/micromamba-win-64
 set REPO_URL=https://github.com/oobabooga/text-generation-webui.git
 set umamba_exists=F
 


### PR DESCRIPTION
Changed link to previous version.
This will provide a stable source for Micromamba so that new versions don't cause issues.

This is in response to: https://github.com/oobabooga/text-generation-webui/issues/626
Hopefully, sticking with a well-known, older version instead of always getting the latest will prevent interruptions due to anti-virus false-flagging.