### PR TITLE
Check the installed python version (numba needs 3.7-3.10)

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -8,6 +8,24 @@
 echo WARNING: This script relies on Micromamba which may have issues on some systems when installed under a path with spaces.
 echo          May also have issues with long paths.&& echo.
 
+@rem Figure out if Python is installed and is one of the supported versions:
+set python_exists=F
+call python --version >nul 2>&1
+if "%ERRORLEVEL%" EQU "0" set python_exists=T
+if "%python_exists%" == "F" (
+    echo You need to have Python version 3.7 to 3.10 installed and in your PATH.
+    echo Note: Python 3.11 is not yet supported by the numba package!
+    echo Install Python 3.10 using the Windows installer from python.org,
+    echo and ensure that the Checkbox "install python.exe into the PATH" is checked!
+    exit 5
+)
+if not call python -c "import sys;exit(sys.version_info[1] not in [7,9,10])" (
+    echo The python.exe in your PATH need to be Python version 3.7 to 3.10!
+    echo Note: Python 3.11 is not yet supported by the numba package:
+    python -c "import sys;print(sys.version)"
+    exit 4
+)
+
 echo What is your GPU?
 echo.
 echo A) NVIDIA


### PR DESCRIPTION
Hi, the install.bat tries to install numba, but this fails with Python 3.11:
```py
  Using cached numba-0.56.4.tar.gz (2.4 MB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-7i5vzfgt/numba_e8d1fd2e45f64ab68cb1bcd4d242a707/setup.py", line 51, in <module>
          _guard_py_ver()
        File "/tmp/pip-install-7i5vzfgt/numba_e8d1fd2e45f64ab68cb1bcd4d242a707/setup.py", line 48, in _guard_py_ver
          raise RuntimeError(msg.format(cur_py, min_py, max_py))
      RuntimeError: Cannot install on Python version 3.11.2; only versions >=3.7,<3.11 are supported.
```
Therefore, I'd propose / contribute a simple check of the python version.

Of course, more could be done, like using the `py` launcher in case it is installed to request it to run a specific python version which is tested.

For now, I've made the check for 3.7 to 3.10 because this is what numba supports, but you might restrict it further.

This specific change is not tested yet, openg it primarily to check if you like the idea.

The implementation is then the second part, but I think it should work this way.

Update: Since the README refers to 3.10.9, I guess it's best to check for 3.10.