### PR TITLE
Add -k flag to curl command

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -48,7 +48,7 @@ if "%PACKAGES_TO_INSTALL%" NEQ "" (
         echo "Downloading Micromamba from %MICROMAMBA_DOWNLOAD_URL% to %MAMBA_ROOT_PREFIX%\micromamba.exe"
 
         mkdir "%MAMBA_ROOT_PREFIX%"
-        call curl -L "%MICROMAMBA_DOWNLOAD_URL%" > "%MAMBA_ROOT_PREFIX%\micromamba.exe" || ( echo Micromamba failed to download. && goto end )
+        call curl -Lk "%MICROMAMBA_DOWNLOAD_URL%" > "%MAMBA_ROOT_PREFIX%\micromamba.exe" || ( echo Micromamba failed to download. && goto end )
 
         @rem test the mamba binary
         echo Micromamba version:


### PR DESCRIPTION
Disables SSL certificate verification which was causing curl to fail on some systems. https://github.com/oobabooga/text-generation-webui/issues/644#issuecomment-1493518391