### PR TITLE
Add working llamaa-cpp-python install from wheel.

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -80,6 +80,7 @@ if exist text-generation-webui\ (
 ) else (
   git clone https://github.com/oobabooga/text-generation-webui.git
   call python -m pip install https://github.com/jllllll/bitsandbytes-windows-webui/raw/main/bitsandbytes-0.37.2-py3-none-any.whl
+  call python -m pip install https://github.com/abetlen/llama-cpp-python/raw/main/wheels/llama_cpp_python-0.1.26-cp310-cp310-win_amd64.whl --no-deps  
   cd text-generation-webui || goto end
 )
 call python -m pip install -r requirements.txt --upgrade


### PR DESCRIPTION
Following https://github.com/abetlen/llama-cpp-python/issues/40 I created PR https://github.com/abetlen/llama-cpp-python/pull/50, tested using "llama-13b-pretrained-sft-do2-4bit-128g.safetensors" installing from scratch multiple times.

 While waiting for that PR to be merged you can test it by swapping for my fork temporarily. 

--no-deps is an artifact from testing, it is likely to work without it.