### PR TITLE
Correct llama-cpp-python wheel link

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -83,7 +83,7 @@ if exist text-generation-webui\ (
 ) else (
   git clone https://github.com/oobabooga/text-generation-webui.git
   call python -m pip install https://github.com/jllllll/bitsandbytes-windows-webui/raw/main/bitsandbytes-0.37.2-py3-none-any.whl
-  call python -m pip install https://github.com/abetlen/llama-cpp-python/raw/main/wheels/llama_cpp_python-0.1.26-cp310-cp310-win_amd64.whl --no-deps  
+  call python -m pip install https://github.com/Loufe/llama-cpp-python/raw/main/wheels/llama_cpp_python-0.1.26-cp310-cp310-win_amd64.whl --no-deps  
   cd text-generation-webui || goto end
 )
 call python -m pip install -r requirements.txt --upgrade

--- a/install.bat
+++ b/install.bat
@@ -8,6 +8,9 @@
 echo WARNING: This script relies on Micromamba which may have issues on some systems when installed under a path with spaces.
 echo          May also have issues with long paths.&& echo.
 
+pause
+cls
+
 echo What is your GPU?
 echo.
 echo A) NVIDIA


### PR DESCRIPTION
[Loufe's pull request](https://github.com/oobabooga/one-click-installers/pull/13) was not ready to be merged yet.

@abetlen has not yet updated his repo to include wheels. As a temporary measure I have changed the link to the llama-cpp-python wheel to point to Loufe's fork.

- Correct llama-cpp-python wheel link
- Ensure that the path warning is actually seen