### PR TITLE
Update llama-cpp-python link to official wheel

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -83,7 +83,6 @@ if exist text-generation-webui\ (
 ) else (
   git clone https://github.com/oobabooga/text-generation-webui.git
   call python -m pip install https://github.com/jllllll/bitsandbytes-windows-webui/raw/main/bitsandbytes-0.37.2-py3-none-any.whl
-  call python -m pip install https://github.com/abetlen/llama-cpp-python/releases/download/v0.1.30/llama_cpp_python-0.1.30-cp310-cp310-win_amd64.whl --no-deps
   cd text-generation-webui || goto end
 )
 call python -m pip install -r requirements.txt --upgrade

--- a/install.bat
+++ b/install.bat
@@ -83,7 +83,7 @@ if exist text-generation-webui\ (
 ) else (
   git clone https://github.com/oobabooga/text-generation-webui.git
   call python -m pip install https://github.com/jllllll/bitsandbytes-windows-webui/raw/main/bitsandbytes-0.37.2-py3-none-any.whl
-  call python -m pip install https://github.com/Loufe/llama-cpp-python/raw/main/wheels/llama_cpp_python-0.1.26-cp310-cp310-win_amd64.whl --no-deps  
+  call python -m pip install https://github.com/abetlen/llama-cpp-python/releases/download/v0.1.30/llama_cpp_python-0.1.30-cp310-cp310-win_amd64.whl --no-deps
   cd text-generation-webui || goto end
 )
 call python -m pip install -r requirements.txt --upgrade

--- a/start-webui.bat
+++ b/start-webui.bat
@@ -13,7 +13,7 @@ if not exist "%MAMBA_ROOT_PREFIX%\condabin\micromamba.bat" (
 call "%MAMBA_ROOT_PREFIX%\condabin\micromamba.bat" activate "%INSTALL_ENV_DIR%" || ( echo MicroMamba hook not found. && goto end )
 cd text-generation-webui
 
-call python server.py --auto-devices --cai-chat
+call python server.py --auto-devices --chat
 
 :end
 pause


### PR DESCRIPTION
llama-cpp-python now has wheels being built automatically and posted the their releases section.

So long as you keep the version in requirements.txt the same as the wheel, you should be able to safely add it back in.

The wheel version in the script is **`0.1.30`**

You could also just put the wheel url directly into the requirements.txt like so:
```
bitsandbytes==0.37.2; platform_system != "Windows"
llama-cpp-python==0.1.30; platform_system != "Windows"
https://github.com/abetlen/llama-cpp-python/releases/download/v0.1.30/llama_cpp_python-0.1.30-cp310-cp310-win_amd64.whl; platform_system == "Windows"
```
In that case, there would be no need for the installer to download the wheel and you would be able to more easily maintain versions. I did not include the bitsandbytes wheel in the example above as it is a custom build for Windows. bitsandbytes currently has no Windows support at all out of the box.