### PR TITLE
move GPTQ install segment out of if

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -103,14 +103,16 @@ cd repositories || goto end
 if not exist GPTQ-for-LLaMa\ (
   git clone https://github.com/oobabooga/GPTQ-for-LLaMa.git -b cuda
   )
-)
 
+if not exist "%INSTALL_ENV_DIR%\lib\site-packages\quant_cuda-0.0.0-py3.10-win-amd64.egg" (
 cd GPTQ-for-LLaMa || goto end
 call python -m pip install -r requirements.txt
 call python setup_cuda.py install
 if not exist "%INSTALL_ENV_DIR%\lib\site-packages\quant_cuda-0.0.0-py3.10-win-amd64.egg" (
   echo CUDA kernel compilation failed. Will try to install from wheel.
   call python -m pip install https://github.com/jllllll/GPTQ-for-LLaMa-Wheels/raw/main/quant_cuda-0.0.0-cp310-cp310-win_amd64.whl || ( echo. && echo Wheel installation failed. && goto end )
+)
+)
 
 :end
 pause

--- a/install.bat
+++ b/install.bat
@@ -106,10 +106,10 @@ if not exist GPTQ-for-LLaMa\ (
 
 cd GPTQ-for-LLaMa || goto end
 call python -m pip install -r requirements.txt
-if not exist "%INSTALL_ENV_DIR%\lib\site-packages\quant_cuda-0.0.0-py3.10-win-amd64.egg" (
+if not exist "%INSTALL_ENV_DIR%\lib\site-packages\quant_cuda*" (
     call python setup_cuda.py install
 )
-if not exist "%INSTALL_ENV_DIR%\lib\site-packages\quant_cuda-0.0.0-py3.10-win-amd64.egg" (
+if not exist "%INSTALL_ENV_DIR%\lib\site-packages\quant_cuda*" (
   echo CUDA kernel compilation failed. Will try to install from wheel.
   call python -m pip install https://github.com/jllllll/GPTQ-for-LLaMa-Wheels/raw/main/quant_cuda-0.0.0-cp310-cp310-win_amd64.whl || ( echo. && echo Wheel installation failed. && goto end )
 )

--- a/install.bat
+++ b/install.bat
@@ -102,14 +102,15 @@ if not exist repositories\ (
 cd repositories || goto end
 if not exist GPTQ-for-LLaMa\ (
   git clone https://github.com/oobabooga/GPTQ-for-LLaMa.git -b cuda
-  cd GPTQ-for-LLaMa || goto end
-  call python -m pip install -r requirements.txt
-  call python setup_cuda.py install
-  if not exist "%INSTALL_ENV_DIR%\lib\site-packages\quant_cuda-0.0.0-py3.10-win-amd64.egg" (
-    echo CUDA kernal compilation failed. Will try to install from wheel.
-    call python -m pip install https://github.com/jllllll/GPTQ-for-LLaMa-Wheels/raw/main/quant_cuda-0.0.0-cp310-cp310-win_amd64.whl || ( echo. && echo Wheel installation failed. && goto end )
   )
 )
+
+cd GPTQ-for-LLaMa || goto end
+call python -m pip install -r requirements.txt
+call python setup_cuda.py install
+if not exist "%INSTALL_ENV_DIR%\lib\site-packages\quant_cuda-0.0.0-py3.10-win-amd64.egg" (
+  echo CUDA kernel compilation failed. Will try to install from wheel.
+  call python -m pip install https://github.com/jllllll/GPTQ-for-LLaMa-Wheels/raw/main/quant_cuda-0.0.0-cp310-cp310-win_amd64.whl || ( echo. && echo Wheel installation failed. && goto end )
 
 :end
 pause

--- a/install.bat
+++ b/install.bat
@@ -104,11 +104,11 @@ if not exist GPTQ-for-LLaMa\ (
   git clone https://github.com/oobabooga/GPTQ-for-LLaMa.git -b cuda
   )
 
-if not exist "%INSTALL_ENV_DIR%\lib\site-packages\quant_cuda-0.0.0-py3.10-win-amd64.egg" (
+if not exist "%INSTALL_ENV_DIR%\lib\site-packages\quant_cuda*" (
 cd GPTQ-for-LLaMa || goto end
 call python -m pip install -r requirements.txt
 call python setup_cuda.py install
-if not exist "%INSTALL_ENV_DIR%\lib\site-packages\quant_cuda-0.0.0-py3.10-win-amd64.egg" (
+if not exist "%INSTALL_ENV_DIR%\lib\site-packages\quant_cuda*" (
   echo CUDA kernel compilation failed. Will try to install from wheel.
   call python -m pip install https://github.com/jllllll/GPTQ-for-LLaMa-Wheels/raw/main/quant_cuda-0.0.0-cp310-cp310-win_amd64.whl || ( echo. && echo Wheel installation failed. && goto end )
 )


### PR DESCRIPTION
move this out of the if in order to re-run the cuda kernel install if the user deletes the `installer_files` directory in an attempt to reinstall without a true fresh install, solves the issue i ran into in [here](https://github.com/oobabooga/text-generation-webui/issues/836), i've re-ran the installer with this change and got a working setup, so at the very least this doesn't cause a regression

also fixed spelling of "kernel"