### PR TITLE
Fixed error when $OS_ARCH returns aarch64

### DIFF
--- a/start_linux.sh
+++ b/start_linux.sh
@@ -8,6 +8,7 @@ OS_ARCH=$(uname -m)
 case "${OS_ARCH}" in
     x86_64*)    OS_ARCH="x86_64";;
     arm64*)     OS_ARCH="aarch64";;
+    aarch64*)     OS_ARCH="aarch64";;
     *)          echo "Unknown system architecture: $OS_ARCH! This script runs only on x86_64 or arm64" && exit
 esac
 


### PR DESCRIPTION
For some machines $OS_ARCH returns aarch64 instead of ARM64,and as i see here this should fix it.