### PR TITLE
Fix Windows PATH fix

### DIFF
--- a/cmd_windows.bat
+++ b/cmd_windows.bat
@@ -2,9 +2,9 @@
 
 cd /D "%~dp0"
 
-echo "%CD%"| findstr /C:" " >nul && echo This script relies on Miniconda which can not be silently installed under a path with spaces. && goto end
-
 set PATH=%PATH%;%SystemRoot%\system32
+
+echo "%CD%"| findstr /C:" " >nul && echo This script relies on Miniconda which can not be silently installed under a path with spaces. && goto end
 
 @rem fix failed install when installing to a separate drive
 set TMP=%cd%\installer_files

--- a/start_windows.bat
+++ b/start_windows.bat
@@ -2,9 +2,9 @@
 
 cd /D "%~dp0"
 
-echo "%CD%"| findstr /C:" " >nul && echo This script relies on Miniconda which can not be silently installed under a path with spaces. && goto end
-
 set PATH=%PATH%;%SystemRoot%\system32
+
+echo "%CD%"| findstr /C:" " >nul && echo This script relies on Miniconda which can not be silently installed under a path with spaces. && goto end
 
 @rem fix failed install when installing to a separate drive
 set TMP=%cd%\installer_files

--- a/update_windows.bat
+++ b/update_windows.bat
@@ -2,9 +2,9 @@
 
 cd /D "%~dp0"
 
-echo "%CD%"| findstr /C:" " >nul && echo This script relies on Miniconda which can not be silently installed under a path with spaces. && goto end
-
 set PATH=%PATH%;%SystemRoot%\system32
+
+echo "%CD%"| findstr /C:" " >nul && echo This script relies on Miniconda which can not be silently installed under a path with spaces. && goto end
 
 @rem fix failed install when installing to a separate drive
 set TMP=%cd%\installer_files


### PR DESCRIPTION
The PATH fix for broken Windows installs needs to come before the use of `findstr` as that is an executable located in System32.
Didn't realize that before now.