### PR TITLE
Adds functionality for user to set flags via environment variable

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -13,6 +13,14 @@ script_dir = os.getcwd()
 CMD_FLAGS = '--chat --model-menu'
 
 
+# Allows users to set flags in "OOBABOOGA_FLAGS" environment variable
+if "OOBABOOGA_FLAGS" in os.environ:
+    CMD_FLAGS = os.environ["OOBABOOGA_FLAGS"]
+    print("\33[1;32mFlags have been taken from enivroment Variable 'OOBABOOGA_FLAGS'\33[0m") 
+    print(CMD_FLAGS)
+    print("\33[1;32mTo use flags from webui.py remove 'OOBABOOGA_FLAGS'\33[0m") 
+
+
 def run_cmd(cmd, assert_success=False, environment=False, capture_output=False, env=None):
     # Use the conda environment
     if environment:


### PR DESCRIPTION
It checks to see if the environment variable OOBABOOGA_FLAGS exists.

If it finds OOBABOOGA_FLAGS it sets CMD_FLAGS  to OOBABOOGA_FLAGS and tell the user that flags are being set by an environment variable instead of inline in webui.py.

If there is no OOBABOOGA_FLAGS it will skip and run as usual.