### PR TITLE
Parse g++ version instead of using string matching

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -133,8 +133,8 @@ def update_dependencies():
     
     # On some Linux distributions, g++ may not exist or be the wrong version to compile GPTQ-for-LLaMa
     if sys.platform.startswith("linux"):
-        gxx_output = run_cmd("g++ --version", environment=True, capture_output=True)
-        if gxx_output.returncode != 0 or b"g++ (GCC) 12" in gxx_output.stdout:
+        gxx_output = run_cmd("g++ -dumpfullversion -dumpversion", environment=True, capture_output=True)
+        if gxx_output.returncode != 0 or int(gxx_output.stdout.strip().split(b".")[0]) > 11:
             # Install the correct version of g++
             run_cmd("conda install -y -k gxx_linux-64=11.2.0", environment=True)
 


### PR DESCRIPTION
The `g++ --version` output is unreliable (my machine has `gcc (Ubuntu 12.2.0-17ubuntu1) 12.2.0`) and the current string matching doesn't support GCC 13 (oobabooga/text-generation-webui/issues/2131).
So instead I copied the [same command that pytorch](https://github.com/pytorch/pytorch/blob/ecd79b1fef4ad8823781b715002ab221c7075732/torch/utils/cpp_extension.py#L349) uses and parse that to get the major version.