### PR TITLE
Install older bitsandbytes on older gpus + fix llama-cpp-python issue

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -98,6 +98,12 @@ def update_dependencies():
         if os.path.exists(extension_req_path):
             run_cmd("python -m pip install -r " + extension_req_path + " --upgrade", assert_success=True, environment=True)
 
+    # Workaround for latest bitsandbytes compatibility with older gpus
+    if sys.platform.startswith("win"):
+        compute_cap = run_cmd("call __nvcc_device_query.exe", environment=True, capture_output=True).stdout
+        if int(compute_cap) < 70:
+            run_cmd("python -m pip install https://github.com/jllllll/bitsandbytes-windows-webui/raw/main/bitsandbytes-0.38.1-py3-none-any.whl --force-reinstall --no-deps", assert_success=True, environment=True)
+
     # The following dependencies are for CUDA, not CPU
     # Check if the package cpuonly exists to determine if torch uses CUDA or not
     cpuonly_exist = run_cmd("conda list cpuonly | grep cpuonly", environment=True, capture_output=True).returncode == 0

--- a/webui.py
+++ b/webui.py
@@ -100,8 +100,8 @@ def update_dependencies():
 
     # Workaround for latest bitsandbytes compatibility with older gpus
     if sys.platform.startswith("win"):
-        compute_cap = run_cmd("call __nvcc_device_query.exe", environment=True, capture_output=True).stdout
-        if int(compute_cap) < 70:
+        compute_array = run_cmd("call __nvcc_device_query.exe", environment=True, capture_output=True).stdout.decode('utf-8').split(',')
+        if not any(int(compute) >= 70 for compute in compute_array):
             run_cmd("python -m pip install https://github.com/jllllll/bitsandbytes-windows-webui/raw/main/bitsandbytes-0.38.1-py3-none-any.whl --force-reinstall --no-deps", assert_success=True, environment=True)
 
     # The following dependencies are for CUDA, not CPU

--- a/webui.py
+++ b/webui.py
@@ -98,17 +98,19 @@ def update_dependencies():
         if os.path.exists(extension_req_path):
             run_cmd("python -m pip install -r " + extension_req_path + " --upgrade", assert_success=True, environment=True)
 
-    # Workaround for latest bitsandbytes compatibility with older gpus
-    if sys.platform.startswith("win"):
-        compute_array = run_cmd("call __nvcc_device_query.exe", environment=True, capture_output=True)
-        if compute_array.returncode == 0 and not any(int(compute) >= 70 for compute in compute_array.stdout.decode('utf-8').split(',')):
-            old_bnb_win = run_cmd("python -m pip install https://github.com/jllllll/bitsandbytes-windows-webui/raw/main/bitsandbytes-0.38.1-py3-none-any.whl --force-reinstall --no-deps", environment=True).returncode == 0
-            print("\n\nWARNING: GPU with compute < 7.0 detected!")
-            if old_bnb_win:
-                print("Older version of bitsandbytes has been installed to maintain compatibility.")
-                print("You will be unable to use --load-in-4bit!\n\n")
-            else:
-                print("You will be unable to use --load-in-8bit until you install bitsandbytes 0.38.1!\n\n")
+    # Latest bitsandbytes requires minimum compute 7.0
+    nvcc_device_query = "__nvcc_device_query" if not sys.platform.startswith("win") else "__nvcc_device_query.exe"
+    min_compute = 70
+    compute_array = run_cmd(os.path.join(conda_env_path, "bin", nvcc_device_query), environment=True, capture_output=True)
+    old_bnb = "bitsandbytes==0.38.1" if not sys.platform.startswith("win") else "https://github.com/jllllll/bitsandbytes-windows-webui/raw/main/bitsandbytes-0.38.1-py3-none-any.whl"
+    if compute_array.returncode == 0 and not any(int(compute) >= min_compute for compute in compute_array.stdout.decode('utf-8').split(',')):
+        old_bnb_install = run_cmd(f"python -m pip install {old_bnb} --force-reinstall --no-deps", environment=True).returncode == 0
+        print("\n\nWARNING: GPU with compute < 7.0 detected!")
+        if old_bnb_install:
+            print("Older version of bitsandbytes has been installed to maintain compatibility.")
+            print("You will be unable to use --load-in-4bit!\n\n")
+        else:
+            print("You will be unable to use --load-in-8bit until you install bitsandbytes 0.38.1!\n\n")
 
     # The following dependencies are for CUDA, not CPU
     # Check if the package cpuonly exists to determine if torch uses CUDA or not

--- a/webui.py
+++ b/webui.py
@@ -108,7 +108,7 @@ def update_dependencies():
                 print("Older version of bitsandbytes has been installed to maintain compatibility.")
                 print("You will be unable to use --load-in-4bit!\n\n")
             else:
-                print("You will be unable to use --load-in-8bit or --load-in-4bit until you install bitsandbytes 0.38.1!\n\n")
+                print("You will be unable to use --load-in-8bit until you install bitsandbytes 0.38.1!\n\n")
 
     # The following dependencies are for CUDA, not CPU
     # Check if the package cpuonly exists to determine if torch uses CUDA or not

--- a/webui.py
+++ b/webui.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 
 script_dir = os.getcwd()
+conda_env_path = os.path.join(script_dir, "installer_files", "env")
 
 # Use this to set your command-line flags. For the full list, see:
 # https://github.com/oobabooga/text-generation-webui/#starting-the-web-ui
@@ -16,7 +17,6 @@ CMD_FLAGS = '--chat --model-menu'
 def run_cmd(cmd, assert_success=False, environment=False, capture_output=False, env=None):
     # Use the conda environment
     if environment:
-        conda_env_path = os.path.join(script_dir, "installer_files", "env")
         if sys.platform.startswith("win"):
             conda_bat_path = os.path.join(script_dir, "installer_files", "conda", "condabin", "conda.bat")
             cmd = "\"" + conda_bat_path + "\" activate \"" + conda_env_path + "\" >nul && " + cmd
@@ -211,6 +211,11 @@ if __name__ == "__main__":
         if len(glob.glob("text-generation-webui/models/*/")) == 0:
             download_model()
             os.chdir(script_dir)
+
+        # Workaround for llama-cpp-python loading paths in CUDA env vars even if they do not exist
+        conda_path_bin = os.path.join(conda_env_path, "bin")
+        if not os.path.exists(conda_path_bin):
+            os.mkdir(conda_path_bin)
 
         # Run the model with webui
         run_model()


### PR DESCRIPTION
Found out that the Cuda Toolkit installed in the environment includes an executable that reports the compute capability of your GPU. This allows for installation of an older bitsandbytes for GPUs that are incompatible with the latest version. This can also allow for installing a version of GPTQ that is compatible with GPUs older than Pascal, though I have not done that here.

This will need to be tested on a system with multiple GPUs. Not very experienced with Python, but I believe it should work. With multiple GPUs, the program outputs comma-separated numbers: `61,75`

This also needs to be tested on Linux to ensure that it works there.

Fixes https://github.com/oobabooga/text-generation-webui/issues/2377

bitsandbytes Windows wheels are now compiled through GitHub Actions:
https://github.com/jllllll/bitsandbytes-windows-webui/actions

---
This now also includes a workaround for an issue I was made aware of with llama-cpp-python.

It was failing to load due to the previous addition of `CUDA_PATH` to the `start_windows.bat` script when installing with the cpu option. It is assuming the presence of `CUDA_PATH` on Windows to mean that the CUDA Toolkit is installed and the relevant paths are accessible: https://github.com/abetlen/llama-cpp-python/blob/main/llama_cpp/llama_cpp.py#L51-L53

The workaround is simply to create the `bin` folder if it is missing.

Fixes https://github.com/oobabooga/text-generation-webui/issues/2417, Fixes #73