### PR TITLE
Installer for WSL

### DIFF
--- a/INSTRUCTIONS-WSL.TXT
+++ b/INSTRUCTIONS-WSL.TXT
@@ -67,8 +67,7 @@ You can also run "wsl.sh cmd" in WSL.
 # Changing the default install location
 
 To change this, you will need to edit the scripts as follows:
-wsl.sh: line ~19   INSTALL_DIR="/path/to/install/dir"
-cmd_wsl.bat: line 7   call wsl -- cd /path/to/install; cd ./dir; ...
+wsl.sh: line ~22   INSTALL_DIR="/path/to/install/dir"
 
 Keep in mind that there is a long-standing bug in WSL that significantly
 slows drive read/write speeds when using a physical drive as opposed to

--- a/INSTRUCTIONS-WSL.TXT
+++ b/INSTRUCTIONS-WSL.TXT
@@ -60,6 +60,8 @@ to be used by the web UI.
 To run an interactive shell in the miniconda environment, run the "cmd"
 script. This is useful for installing additional requirements manually.
 
+You can also run "wsl.sh cmd" in WSL.
+
 # Changing the default install location
 
 To change this, you will need to edit the scripts as follows:

--- a/INSTRUCTIONS-WSL.TXT
+++ b/INSTRUCTIONS-WSL.TXT
@@ -1,6 +1,34 @@
 Thank you for downloading oobabooga/text-generation-webui.
 
-# Installation
+# WSL setup
+
+If you do not have WSL installed, see here:
+https://learn.microsoft.com/en-us/windows/wsl/install
+
+If you want to install Linux to a drive other than C
+Open powershell and enter these commands:
+
+cd D:\Path\To\Linux
+$ProgressPreference = 'SilentlyContinue'
+Invoke-WebRequest -Uri <LinuxDistroURL> -OutFile Linux.appx -UseBasicParsing
+mv Linux.appx Linux.zip
+
+Then open Linux.zip and you should see several .appx files inside.
+The one with _x64.appx contains the exe installer that you need.
+Extract the contents of that _x64.appx file and run <distro>.exe to install.
+
+Linux Distro URLs:
+https://learn.microsoft.com/en-us/windows/wsl/install-manual#downloading-distributions
+
+******************************************************************************
+*ENSURE THAT THE WSL LINUX DISTRO THAT YOU WISH TO USE IS SET AS THE DEFAULT!*
+******************************************************************************
+
+Do this by using these commands:
+wsl -l
+wsl -s <DistroName>
+
+# Web UI Installation
 
 Run the "start" script. By default it will install the web UI in WSL:
 /home/{username}/text-gen-install

--- a/INSTRUCTIONS-WSL.TXT
+++ b/INSTRUCTIONS-WSL.TXT
@@ -41,6 +41,8 @@ the same "start" script. Ensure that webui.py and wsl.sh are next to it!
 Run the "update" script. This will only install the updates, so it should
 be much faster than the initial installation.
 
+You can also run "wsl.sh update" in WSL.
+
 # Adding flags like --chat, --notebook, etc
 
 Edit the "webui.py" script using a text editor and add the desired flags

--- a/INSTRUCTIONS-WSL.TXT
+++ b/INSTRUCTIONS-WSL.TXT
@@ -1,0 +1,43 @@
+Thank you for downloading oobabooga/text-generation-webui.
+
+# Installation
+
+Run the "start" script. By default it will install the web UI in WSL:
+/home/{username}/text-gen-install
+
+To launch the web UI in the future after it is already installed, run
+the same "start" script. Ensure that webui.py and wsl.sh are next to it!
+
+# Updating the web UI
+
+Run the "update" script. This will only install the updates, so it should
+be much faster than the initial installation.
+
+# Adding flags like --chat, --notebook, etc
+
+Edit the "webui.py" script using a text editor and add the desired flags
+to the CMD_FLAGS variable at the top. It should look like this:
+
+CMD_FLAGS = '--chat'
+
+For instance, to add the --api flag, change it to
+
+CMD_FLAGS = '--chat --api'
+
+The "start" and "update" scripts will copy the edited "webui.py" to WSL
+to be used by the web UI.
+
+# Running an interactive shell
+
+To run an interactive shell in the miniconda environment, run the "cmd"
+script. This is useful for installing additional requirements manually.
+
+# Changing the default install location
+
+To change this, you will need to edit the scripts as follows:
+wsl.sh: line ~19   INSTALL_DIR="/path/to/install/dir"
+cmd_wsl.bat: line 7   call wsl -- cd /path/to/install; cd ./dir; ...
+
+Keep in mind that there is a long-standing bug in WSL that significantly
+slows drive read/write speeds when using a physical drive as opposed to
+the virtual one that Linux is installed in.

--- a/cmd_wsl.bat
+++ b/cmd_wsl.bat
@@ -4,6 +4,7 @@ cd /D "%~dp0"
 
 set PATH=%PATH%;%SystemRoot%\system32
 
+@rem This will run a series of bash commands in WSL to activate conda env and open CLI   2 cd commands are used to allow the second to fail and still provide a CLI when webui is not installed
 call wsl -- cd $HOME; cd ./text-gen-install; export INSTALL_DIR="$(pwd)"; export CONDA_ROOT_PREFIX="$INSTALL_DIR/installer_files/conda"; export INSTALL_ENV_DIR="$INSTALL_DIR/installer_files/env"; exec bash -lic "source $CONDA_ROOT_PREFIX/etc/profile.d/conda.sh; conda activate $INSTALL_ENV_DIR; exec bash"
 
 :end

--- a/cmd_wsl.bat
+++ b/cmd_wsl.bat
@@ -4,8 +4,8 @@ cd /D "%~dp0"
 
 set PATH=%PATH%;%SystemRoot%\system32
 
-@rem sed -i 's/\x0D$//' ./wsl.sh converts newlines to unix format in the wsl script   calling wsl.sh with 'cmd' will open a cli in conda env
-call wsl -e bash -lic "sed -i 's/\x0D$//' ./wsl.sh; source ./wsl.sh cmd"
+@rem This will run a series of bash commands in WSL to activate conda env and open CLI   2 cd commands are used to allow the second to fail and still provide a CLI when webui is not installed
+call wsl -- cd $HOME; cd ./text-gen-install; export INSTALL_DIR="$(pwd)"; export CONDA_ROOT_PREFIX="$INSTALL_DIR/installer_files/conda"; export INSTALL_ENV_DIR="$INSTALL_DIR/installer_files/env"; exec bash -lic "source $CONDA_ROOT_PREFIX/etc/profile.d/conda.sh; conda activate $INSTALL_ENV_DIR; exec bash"
 
 :end
 pause

--- a/cmd_wsl.bat
+++ b/cmd_wsl.bat
@@ -1,0 +1,10 @@
+@echo off
+
+cd /D "%~dp0"
+
+set PATH=%PATH%;%SystemRoot%\system32
+
+call wsl -- cd $HOME; cd ./text-gen-install; export INSTALL_DIR="$(pwd)"; export CONDA_ROOT_PREFIX="$INSTALL_DIR/installer_files/conda"; export INSTALL_ENV_DIR="$INSTALL_DIR/installer_files/env"; exec bash -lic "source $CONDA_ROOT_PREFIX/etc/profile.d/conda.sh; conda activate $INSTALL_ENV_DIR; exec bash"
+
+:end
+pause

--- a/cmd_wsl.bat
+++ b/cmd_wsl.bat
@@ -4,8 +4,8 @@ cd /D "%~dp0"
 
 set PATH=%PATH%;%SystemRoot%\system32
 
-@rem This will run a series of bash commands in WSL to activate conda env and open CLI   2 cd commands are used to allow the second to fail and still provide a CLI when webui is not installed
-call wsl -- cd $HOME; cd ./text-gen-install; export INSTALL_DIR="$(pwd)"; export CONDA_ROOT_PREFIX="$INSTALL_DIR/installer_files/conda"; export INSTALL_ENV_DIR="$INSTALL_DIR/installer_files/env"; exec bash -lic "source $CONDA_ROOT_PREFIX/etc/profile.d/conda.sh; conda activate $INSTALL_ENV_DIR; exec bash"
+@rem sed -i 's/\x0D$//' ./wsl.sh converts newlines to unix format in the wsl script   calling wsl.sh with 'cmd' will open a cli in conda env
+call wsl -e bash -lic "sed -i 's/\x0D$//' ./wsl.sh; source ./wsl.sh cmd"
 
 :end
 pause

--- a/cmd_wsl.bat
+++ b/cmd_wsl.bat
@@ -4,8 +4,8 @@ cd /D "%~dp0"
 
 set PATH=%PATH%;%SystemRoot%\system32
 
-@rem This will run a series of bash commands in WSL to activate conda env and open CLI   2 cd commands are used to allow the second to fail and still provide a CLI when webui is not installed
-call wsl -- cd $HOME; cd ./text-gen-install; export INSTALL_DIR="$(pwd)"; export CONDA_ROOT_PREFIX="$INSTALL_DIR/installer_files/conda"; export INSTALL_ENV_DIR="$INSTALL_DIR/installer_files/env"; exec bash -lic "source $CONDA_ROOT_PREFIX/etc/profile.d/conda.sh; conda activate $INSTALL_ENV_DIR; exec bash"
+@rem sed -i 's/\x0D$//' ./wsl.sh converts newlines to unix format in the wsl script
+call wsl -e bash -lic "sed -i 's/\x0D$//' ./wsl.sh; source ./wsl.sh cmd"
 
 :end
 pause

--- a/generate_zips.sh
+++ b/generate_zips.sh
@@ -1,5 +1,6 @@
-mkdir oobabooga_{windows,linux,macos}
-for p in windows macos linux; do
-  cp {*$p*\.*,webui.py,INSTRUCTIONS.TXT} oobabooga_$p;
+mkdir oobabooga_{windows,linux,macos,wsl}
+for p in windows macos linux wsl; do
+  if [ "$p" == "wsl" ]; then cp {*$p*\.*,webui.py,INSTRUCTIONS-WSL.TXT} oobabooga_$p;
+  else cp {*$p*\.*,webui.py,INSTRUCTIONS.TXT} oobabooga_$p; fi
   zip -r oobabooga_$p.zip oobabooga_$p;
 done

--- a/start_wsl.bat
+++ b/start_wsl.bat
@@ -1,0 +1,10 @@
+@echo off
+
+cd /D "%~dp0"
+
+set PATH=%PATH%;%SystemRoot%\system32
+
+call wsl -e bash -lic "sed -i 's/\x0D$//' ./wsl.sh; source ./wsl.sh"
+
+:end
+pause

--- a/start_wsl.bat
+++ b/start_wsl.bat
@@ -4,6 +4,7 @@ cd /D "%~dp0"
 
 set PATH=%PATH%;%SystemRoot%\system32
 
+@rem sed -i 's/\x0D$//' ./wsl.sh converts newlines to unix format in the wsl script
 call wsl -e bash -lic "sed -i 's/\x0D$//' ./wsl.sh; source ./wsl.sh"
 
 :end

--- a/update_wsl.bat
+++ b/update_wsl.bat
@@ -4,6 +4,7 @@ cd /D "%~dp0"
 
 set PATH=%PATH%;%SystemRoot%\system32
 
+@rem sed -i 's/\x0D$//' ./wsl.sh converts newlines to unix format in the wsl script   calling wsl.sh with 'update' will run updater
 call wsl -e bash -lic "sed -i 's/\x0D$//' ./wsl.sh; source ./wsl.sh update"
 
 :end

--- a/update_wsl.bat
+++ b/update_wsl.bat
@@ -1,0 +1,10 @@
+@echo off
+
+cd /D "%~dp0"
+
+set PATH=%PATH%;%SystemRoot%\system32
+
+call wsl -e bash -lic "sed -i 's/\x0D$//' ./wsl.sh; source ./wsl.sh update"
+
+:end
+pause

--- a/wsl.sh
+++ b/wsl.sh
@@ -75,6 +75,8 @@ source "$CONDA_ROOT_PREFIX/etc/profile.d/conda.sh" # otherwise conda complains a
 conda activate "$INSTALL_ENV_DIR"
 
 # setup installer env   update env if called with 'wsl.sh update'
-if [ "$1" == "update" ]; then python webui.py --update
-else python webui.py
-fi
+case "$1" in
+("update") python webui.py --update;;
+("cmd") exec bash;;
+(*) python webui.py;;
+esac

--- a/wsl.sh
+++ b/wsl.sh
@@ -27,7 +27,7 @@ if [[ "$INSTALL_DIR" =~ " " ]]; then echo This script relies on Miniconda which 
 
 # create install dir if missing and copy webui.py to install dir to maintain functionality without edit
 if [ ! -d "$INSTALL_DIR" ]; then mkdir -p "$INSTALL_DIR" || exit; fi
-cp "./webui.py" "$INSTALL_DIR"
+cp -u "./webui.py" "$INSTALL_DIR"
 
 # figure out whether git and conda needs to be installed
 if "$CONDA_ROOT_PREFIX/bin/conda" --version &>/dev/null; then conda_exists="T"; fi

--- a/wsl.sh
+++ b/wsl.sh
@@ -70,4 +70,6 @@ source "$CONDA_ROOT_PREFIX/etc/profile.d/conda.sh" # otherwise conda complains a
 conda activate "$INSTALL_ENV_DIR"
 
 # setup installer env
-python webui.py
+if [ "$1" == "update" ]; then python webui.py --update
+else python webui.py
+fi

--- a/wsl.sh
+++ b/wsl.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# detect if build-essential is missing or broken
+if ! dpkg-query -W -f'${Status}' "build-essential" 2>/dev/null | grep -q "ok installed"; then
+echo "build-essential not found or broken!
+
+A C++ compiler is required to build needed Python packages!
+To install one, run cmd_wsl.bat and enter these commands:
+
+sudo apt-get update
+sudo apt-get install build-essential
+"
+read -n1 -p "Continue the installer anyway? [y,n]" EXIT_PROMPT
+if ! [[ $EXIT_PROMPT == "Y" || $EXIT_PROMPT == "y" ]]; then exit; fi
+fi
+
+
+# config
+INSTALL_DIR="$HOME/text-gen-install"
+CONDA_ROOT_PREFIX="$INSTALL_DIR/installer_files/conda"
+INSTALL_ENV_DIR="$INSTALL_DIR/installer_files/env"
+MINICONDA_DOWNLOAD_URL="https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh"
+conda_exists="F"
+
+if [[ "$INSTALL_DIR" =~ " " ]]; then echo This script relies on Miniconda which can not be silently installed under a path with spaces. && exit; fi
+if [ ! -d "$INSTALL_DIR" ]; then mkdir -p "$INSTALL_DIR" || exit; fi
+cp -u "./webui.py" "$INSTALL_DIR"
+
+# figure out whether git and conda needs to be installed
+if "$CONDA_ROOT_PREFIX/bin/conda" --version &>/dev/null; then conda_exists="T"; fi
+
+# (if necessary) install git and conda into a contained environment
+# download miniconda
+if [ "$conda_exists" == "F" ]; then
+    echo "Downloading Miniconda from $MINICONDA_DOWNLOAD_URL to $INSTALL_DIR/miniconda_installer.sh"
+
+    curl -Lk "$MINICONDA_DOWNLOAD_URL" > "$INSTALL_DIR/miniconda_installer.sh"
+
+    chmod u+x "$INSTALL_DIR/miniconda_installer.sh"
+    bash "$INSTALL_DIR/miniconda_installer.sh" -b -p $CONDA_ROOT_PREFIX
+
+    # test the conda binary
+    echo "Miniconda version:"
+    "$CONDA_ROOT_PREFIX/bin/conda" --version
+fi
+
+cd $INSTALL_DIR
+
+# create the installer env
+if [ ! -e "$INSTALL_ENV_DIR" ]; then
+    "$CONDA_ROOT_PREFIX/bin/conda" create -y -k --prefix "$INSTALL_ENV_DIR" python=3.10
+fi
+
+# check if conda environment was actually created
+if [ ! -e "$INSTALL_ENV_DIR/bin/python" ]; then
+    echo "Conda environment is empty."
+    exit
+fi
+
+# environment isolation
+export PYTHONNOUSERSITE=1
+unset PYTHONPATH
+unset PYTHONHOME
+export CUDA_PATH="$INSTALL_ENV_DIR"
+export CUDA_HOME="$CUDA_PATH"
+export LD_LIBRARY_PATH="$CUDA_HOME/lib:/usr/lib/wsl/lib:$LD_LIBRARY_PATH"
+
+# activate installer env
+source "$CONDA_ROOT_PREFIX/etc/profile.d/conda.sh" # otherwise conda complains about 'shell not initialized' (needed when running in a script)
+conda activate "$INSTALL_ENV_DIR"
+
+# setup installer env
+python webui.py

--- a/wsl.sh
+++ b/wsl.sh
@@ -15,6 +15,8 @@ read -n1 -p "Continue the installer anyway? [y,n]" EXIT_PROMPT
 if ! [[ $EXIT_PROMPT == "Y" || $EXIT_PROMPT == "y" ]]; then exit; fi
 fi
 
+# deactivate any currently active conda env
+conda deactivate 2> /dev/null
 
 # config   unlike other scripts, can't use current directory due to file IO bug in WSL, needs to be in virtual drive
 INSTALL_DIR="$HOME/text-gen-install"
@@ -22,6 +24,22 @@ CONDA_ROOT_PREFIX="$INSTALL_DIR/installer_files/conda"
 INSTALL_ENV_DIR="$INSTALL_DIR/installer_files/env"
 MINICONDA_DOWNLOAD_URL="https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh"
 conda_exists="F"
+
+# environment isolation
+export PYTHONNOUSERSITE=1
+unset PYTHONPATH
+unset PYTHONHOME
+export CUDA_PATH="$INSTALL_ENV_DIR"
+export CUDA_HOME="$CUDA_PATH"
+
+# /usr/lib/wsl/lib needs to be added to LD_LIBRARY_PATH to fix years-old bug in WSL where GPU drivers aren't linked properly
+export LD_LIBRARY_PATH="$CUDA_HOME/lib:/usr/lib/wsl/lib:$LD_LIBRARY_PATH"
+
+# open bash cli if called with 'wsl.sh cmd' with workarounds for existing conda
+if [ "$1" == "cmd" ]; then
+    exec bash --init-file <(echo ". ~/.bashrc; conda deactivate 2> /dev/null; cd $INSTALL_DIR || cd $HOME; source $CONDA_ROOT_PREFIX/etc/profile.d/conda.sh; conda activate $INSTALL_ENV_DIR")
+    exit
+fi
 
 if [[ "$INSTALL_DIR" =~ " " ]]; then echo This script relies on Miniconda which can not be silently installed under a path with spaces. && exit; fi
 
@@ -60,16 +78,6 @@ if [ ! -e "$INSTALL_ENV_DIR/bin/python" ]; then
     exit
 fi
 
-# environment isolation
-export PYTHONNOUSERSITE=1
-unset PYTHONPATH
-unset PYTHONHOME
-export CUDA_PATH="$INSTALL_ENV_DIR"
-export CUDA_HOME="$CUDA_PATH"
-
-# /usr/lib/wsl/lib needs to be added to LD_LIBRARY_PATH to fix years-old bug in WSL where GPU drivers aren't linked properly
-export LD_LIBRARY_PATH="$CUDA_HOME/lib:/usr/lib/wsl/lib:$LD_LIBRARY_PATH"
-
 # activate installer env
 source "$CONDA_ROOT_PREFIX/etc/profile.d/conda.sh" # otherwise conda complains about 'shell not initialized' (needed when running in a script)
 conda activate "$INSTALL_ENV_DIR"
@@ -77,6 +85,5 @@ conda activate "$INSTALL_ENV_DIR"
 # setup installer env   update env if called with 'wsl.sh update'
 case "$1" in
 ("update") python webui.py --update;;
-("cmd") exec bash;;
 (*) python webui.py;;
 esac


### PR DESCRIPTION
This installer is designed to be run in Windows like the Windows installer by double-clicking the `start_wsl.bat` script. The installer will check to see if the `build-essential` package is installed and ready to use and provide installation instructions if it is not. In my testing, this was needed to compile `llama-cpp-python` and all C++ compilers installable through Conda did not work. An option to continue without `build-essential` is included just in case.

Due to the need for `LF` line endings in the `wsl.sh` script, and the fact that git converts them to `CRLF` by default, the `start_wsl.bat` script will convert the line endings when run.

When installing, `webui.py` is copied to the installation directory to be used as-is. If command-line flags are added to it in Windows, the copy in WSL will be automatically replaced with the newer one. This should eliminate the need to use the WSL command-line every time the user wishes to modify `webui.py`.

GPTQ-for-LLaMA, AutoGPTQ, llama-cpp-python, bitsandbytes and normal inference works. I was unable to test Triton due to an ongoing issue with Pascal cards (lucky me). I was also unable to test 4bit bitsandbytes as it is not compatible with my 1080ti. I am also unable to test 30b models due to memory constraints.

Things left to do:
- [x] ~Add WSL-specific instructions.~
- [x] ~Add update script.~
- [x] ~Add comments in the scripts where needed.~
- [x] ~Add relevant files to the `generate_zips.sh` script.~
- [x] ~Update WSL instructions to include WSL setup.~
- [x] ~Deal with pre-existing and globally activated Conda installs~

Any suggestions are welcome! I'm not very experienced with Bash or Linux in general.

--------
The `wsl.sh` script is now capable of being executed directly within WSL. This should allow users more comfortable with the Linux command-line to use the installer in a more familiar way.