### PR TITLE
Check for special characters in installation path on Windows

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -68,6 +68,15 @@ def check_env():
 
 
 def install_dependencies():
+    # Check for special characters in installation path on Windows
+    if sys.platform.startswith("win"):
+        # punctuation contains:  !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+        from string import punctuation
+        # Allow some characters:  _-:\/.'"
+        special_characters = punctuation.translate({ord(char): None for char in '_-:\\/.\'"'})
+        if any(char in script_dir for char in special_characters):
+            print_big_message("WARNING: Special characters were detected in the installation path!\n         This can cause the installation to fail!")
+
     # Select your GPU or, choose to run in CPU mode
     print("What is your GPU")
     print()


### PR DESCRIPTION
Windows Miniconda installer does not allow special characters in the installation path. Displays a warning message if detected.
Couldn't find a list of specific characters that it checks for.

Not too sure if detection is necessary or not. Could just display a message on Windows by default.

Checking for these characters: ```!#$%&()*+,;<=>?@[]^`{|}~```

This is a response to: https://github.com/oobabooga/text-generation-webui/issues/1351#issuecomment-1589924256