### PR TITLE
Fix cmd_macos.sh

### DIFF
--- a/cmd_macos.sh
+++ b/cmd_macos.sh
@@ -4,6 +4,9 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 if [[ "$(pwd)" =~ " " ]]; then echo This script relies on Miniconda which can not be silently installed under a path with spaces. && exit; fi
 
+# deactivate existing env if needed
+conda deactivate 2> /dev/null
+
 # config
 CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda"
 INSTALL_ENV_DIR="$(pwd)/installer_files/env"
@@ -16,4 +19,6 @@ export CUDA_PATH="$INSTALL_ENV_DIR"
 export CUDA_HOME="$CUDA_PATH"
 
 # activate env
-bash --init-file <(echo "source \"$CONDA_ROOT_PREFIX/etc/profile.d/conda.sh\" && conda activate \"$INSTALL_ENV_DIR\"")
+source $CONDA_ROOT_PREFIX/etc/profile.d/conda.sh
+conda activate $INSTALL_ENV_DIR
+exec bash --norc


### PR DESCRIPTION
Some MacOS versions of Bash do not support process substitution `<()` in the way that it is done here. A user on the Discord server encountered this as I was helping them with something.
Fortunately, it isn't necessary and the same effect can be achieved in the way that I have done it here.