### PR TITLE
Install exllama

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -158,10 +158,17 @@ def update_dependencies():
     if not os.path.exists("repositories/"):
         os.mkdir("repositories")
 
-    # Install exllama and GPTQ-for-LLaMa which enables 4bit CUDA quantization
     os.chdir("repositories")
+        
+    # Install or update exllama as needed
     if not os.path.exists("exllama/"):
         run_cmd("git clone https://github.com/turboderp/exllama.git", environment=True)
+    else:
+        os.chdir("exllama")
+        run_cmd("git pull", environment=True)
+        os.chdir("..")
+    
+    # Install GPTQ-for-LLaMa which enables 4bit CUDA quantization
     if not os.path.exists("GPTQ-for-LLaMa/"):
         run_cmd("git clone https://github.com/oobabooga/GPTQ-for-LLaMa.git -b cuda", assert_success=True, environment=True)
 

--- a/webui.py
+++ b/webui.py
@@ -158,8 +158,10 @@ def update_dependencies():
     if not os.path.exists("repositories/"):
         os.mkdir("repositories")
 
-    # Install GPTQ-for-LLaMa which enables 4bit CUDA quantization
+    # Install exllama and GPTQ-for-LLaMa which enables 4bit CUDA quantization
     os.chdir("repositories")
+    if not os.path.exists("exllama/"):
+        run_cmd("git clone https://github.com/turboderp/exllama.git", environment=True)
     if not os.path.exists("GPTQ-for-LLaMa/"):
         run_cmd("git clone https://github.com/oobabooga/GPTQ-for-LLaMa.git -b cuda", assert_success=True, environment=True)
 


### PR DESCRIPTION
Simple git clone when installed with NVIDIA option. `git pull` is used to update exllama if already cloned.

`assert_success` is not used to allow the command to fail and not block GPTQ-for-LLaMa installation.
Rest of the code afterwards is for GPTQ-for-LLaMa, so the GPTQ clone still uses `assert_success`.