### PR TITLE
Install Pytorch through pip instead of Conda

### DIFF
--- a/start_linux.sh
+++ b/start_linux.sh
@@ -16,7 +16,7 @@ esac
 INSTALL_DIR="$(pwd)/installer_files"
 CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda"
 INSTALL_ENV_DIR="$(pwd)/installer_files/env"
-MINICONDA_DOWNLOAD_URL="https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Linux-${OS_ARCH}.sh"
+MINICONDA_DOWNLOAD_URL="https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-Linux-${OS_ARCH}.sh"
 conda_exists="F"
 
 # figure out whether git and conda needs to be installed

--- a/start_macos.sh
+++ b/start_macos.sh
@@ -16,7 +16,7 @@ esac
 INSTALL_DIR="$(pwd)/installer_files"
 CONDA_ROOT_PREFIX="$(pwd)/installer_files/conda"
 INSTALL_ENV_DIR="$(pwd)/installer_files/env"
-MINICONDA_DOWNLOAD_URL="https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-MacOSX-${OS_ARCH}.sh"
+MINICONDA_DOWNLOAD_URL="https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-MacOSX-${OS_ARCH}.sh"
 conda_exists="F"
 
 # figure out whether git and conda needs to be installed

--- a/start_windows.bat
+++ b/start_windows.bat
@@ -14,7 +14,7 @@ set TEMP=%cd%\installer_files
 set INSTALL_DIR=%cd%\installer_files
 set CONDA_ROOT_PREFIX=%cd%\installer_files\conda
 set INSTALL_ENV_DIR=%cd%\installer_files\env
-set MINICONDA_DOWNLOAD_URL=https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Windows-x86_64.exe
+set MINICONDA_DOWNLOAD_URL=https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-Windows-x86_64.exe
 set conda_exists=F
 
 @rem figure out whether git and conda needs to be installed

--- a/webui.py
+++ b/webui.py
@@ -104,9 +104,6 @@ def install_dependencies():
 
     # Clone webui to our computer
     run_cmd("git clone https://github.com/oobabooga/text-generation-webui.git", assert_success=True, environment=True)
-    # if sys.platform.startswith("win"):
-    #     # Fix a bitsandbytes compatibility issue with Windows
-    #     run_cmd("python -m pip install https://github.com/jllllll/bitsandbytes-windows-webui/raw/main/bitsandbytes-0.38.1-py3-none-any.whl", assert_success=True, environment=True)
 
     # Install the webui dependencies
     update_dependencies()
@@ -164,8 +161,8 @@ def update_dependencies():
         sys.exit()
 
     # Fix a bitsandbytes compatibility issue with Linux
-    if sys.platform.startswith("linux"):
-        shutil.copy(os.path.join(site_packages_path, "bitsandbytes", "libbitsandbytes_cuda117.so"), os.path.join(site_packages_path, "bitsandbytes", "libbitsandbytes_cpu.so"))
+    # if sys.platform.startswith("linux"):
+    #     shutil.copy(os.path.join(site_packages_path, "bitsandbytes", "libbitsandbytes_cuda117.so"), os.path.join(site_packages_path, "bitsandbytes", "libbitsandbytes_cpu.so"))
 
     if not os.path.exists("repositories/"):
         os.mkdir("repositories")
@@ -179,6 +176,10 @@ def update_dependencies():
         os.chdir("exllama")
         run_cmd("git pull", environment=True)
         os.chdir("..")
+    
+    # Fix build issue with exllama in Linux/WSL
+    if sys.platform.startswith("linux") and not os.path.exists(f"{conda_env_path}/lib64"):
+        run_cmd(f'ln -s "{conda_env_path}/lib" "{conda_env_path}/lib64"', environment=True)
     
     # Install GPTQ-for-LLaMa which enables 4bit CUDA quantization
     if not os.path.exists("GPTQ-for-LLaMa/"):

--- a/webui.py
+++ b/webui.py
@@ -92,7 +92,7 @@ def install_dependencies():
 
     # Install the version of PyTorch needed
     if gpuchoice == "a":
-        run_cmd('conda install -y -k cuda-toolkit ninja git -c nvidia/label/cuda-11.7.0 -c nvidia && python -m pip install torch==2.0.1+cu117 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu117', assert_success=True, environment=True)
+        run_cmd('conda install -y -k cuda ninja git -c nvidia/label/cuda-11.7.0 -c nvidia && python -m pip install torch==2.0.1+cu117 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu117', assert_success=True, environment=True)
     elif gpuchoice == "b":
         print("AMD GPUs are not supported. Exiting...")
         sys.exit()

--- a/webui.py
+++ b/webui.py
@@ -145,8 +145,8 @@ def update_dependencies():
     torver_cmd = run_cmd("python -m pip show torch", assert_success=True, environment=True, capture_output=True)
     torver = [v.split()[1] for v in torver_cmd.stdout.decode('utf-8').splitlines() if 'Version:' in v][0]
     
-    # Check for '+cu' in version string to determine if torch uses CUDA or not
-    if '+cu' not in torver:
+    # Check for '+cu' in version string to determine if torch uses CUDA or not   check for pytorch-cuda as well for backwards compatibility
+    if '+cu' not in torver and run_cmd("conda list -f pytorch-cuda | grep pytorch-cuda", environment=True, capture_output=True).returncode == 1:
         return
 
     # Finds the path to your dependencies

--- a/wsl.sh
+++ b/wsl.sh
@@ -22,7 +22,7 @@ conda deactivate 2> /dev/null
 INSTALL_DIR="$HOME/text-gen-install"
 CONDA_ROOT_PREFIX="$INSTALL_DIR/installer_files/conda"
 INSTALL_ENV_DIR="$INSTALL_DIR/installer_files/env"
-MINICONDA_DOWNLOAD_URL="https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh"
+MINICONDA_DOWNLOAD_URL="https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-Linux-x86_64.sh"
 conda_exists="F"
 
 # environment isolation


### PR DESCRIPTION
Installation through Conda seems to be fairly unreliable. People have ended up with the CPU-only build of Pytorch far too many times, even when explicitly telling Conda to install the CUDA 11.7 build. There have also been instances where RWKV will not work with the Conda package.

Installing Pytorch through pip will allow for some initial groundwork for basic AMD ROCm support in the future.
Theoretically, it may also allow for out-of-the-box MPS (Metal) GPU acceleration in Pytorch on supported MacOS versions.

I don't think abandoning Conda altogether is an option as it is used to install CUDA Toolkit, Git and Python for systems that don't have those already.

What are your thoughts on this?

---
Included changes:
- Install Pytorch through pip instead of Conda
- Fix for an issue building exllama in Linux/WSL
- Use 'cuda' Conda package instead of 'cuda-toolkit'
  - This conforms to the official CUDA Toolkit installation instructions.
- Upgrade Miniconda version to 23.3.1
- Commented out an old bitsandbytes fix for Linux that no longer seems to be necessary