### PR TITLE
Move special character check to start script

### DIFF
--- a/start_windows.bat
+++ b/start_windows.bat
@@ -6,6 +6,13 @@ set PATH=%PATH%;%SystemRoot%\system32
 
 echo "%CD%"| findstr /C:" " >nul && echo This script relies on Miniconda which can not be silently installed under a path with spaces. && goto end
 
+@rem Check for special characters in installation path
+set "SPCHARMESSAGE="WARNING: Special characters were detected in the installation path!" "         This can cause the installation to fail!""
+echo "%CD%"| findstr /R /C:"[!#\$%&()\*+,;<=>?@\[\]\^`{|}~]" >nul && (
+	call :PrintBigMessage %SPCHARMESSAGE%
+)
+set SPCHARMESSAGE=
+
 @rem fix failed install when installing to a separate drive
 set TMP=%cd%\installer_files
 set TEMP=%cd%\installer_files
@@ -39,8 +46,8 @@ if "%conda_exists%" == "F" (
 
 @rem create the installer env
 if not exist "%INSTALL_ENV_DIR%" (
-  echo Packages to install: %PACKAGES_TO_INSTALL%
-  call "%CONDA_ROOT_PREFIX%\_conda.exe" create --no-shortcuts -y -k --prefix "%INSTALL_ENV_DIR%" python=3.10 || ( echo. && echo Conda environment creation failed. && goto end )
+	echo Packages to install: %PACKAGES_TO_INSTALL%
+	call "%CONDA_ROOT_PREFIX%\_conda.exe" create --no-shortcuts -y -k --prefix "%INSTALL_ENV_DIR%" python=3.10 || ( echo. && echo Conda environment creation failed. && goto end )
 )
 
 @rem check if conda environment was actually created
@@ -58,6 +65,17 @@ call "%CONDA_ROOT_PREFIX%\condabin\conda.bat" activate "%INSTALL_ENV_DIR%" || ( 
 
 @rem setup installer env
 call python webui.py
+
+@rem below are functions for the script   next line skips these during normal execution
+goto end
+
+:PrintBigMessage
+echo. && echo.
+echo *******************************************************************
+for %%M in (%*) do echo * %%~M
+echo *******************************************************************
+echo. && echo.
+exit /b
 
 :end
 pause

--- a/webui.py
+++ b/webui.py
@@ -67,16 +67,6 @@ def check_env():
 
 
 def install_dependencies():
-    # Check for special characters in installation path on Windows
-    if sys.platform.startswith("win"):
-        # punctuation contains:  !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
-        from string import punctuation
-
-        # Allow some characters:  _-:\/.'"
-        special_characters = punctuation.translate({ord(char): None for char in '_-:\\/.\'"'})
-        if any(char in script_dir for char in special_characters):
-            print_big_message("WARNING: Special characters were detected in the installation path!\n         This can cause the installation to fail!")
-
     # Select your GPU or, choose to run in CPU mode
     print("What is your GPU")
     print()


### PR DESCRIPTION
The check was not working as intended due to it taking place after it actually mattered. Didn't think of that when I added it.

Also ported the `print_big_message` function to batch for use here and in the future.

Usage syntax with examples:

```
set "MESSAGEVARIABLE="First line enclosed in quotes." "Second line enclosed in quotes with whole variable contents also enclosed." "Any number of lines supported.""

call :PrintBigMessage %MESSAGEVARIABLE%

call :PrintBigMessage "First line enclosed in quotes." "Second line enclosed in quotes with whole variable contents also enclosed." "Any number of lines supported."

call :PrintBigMessage "First line enclosed in quotes." %MESSAGEVARIABLE% "Can be mixed with variables."

*******************************************************************
* First line enclosed in quotes.
* Second line enclosed in quotes with whole variable contents also enclosed.
* Any number of lines supported.
*******************************************************************
```