### PR TITLE
Add AMD GPU support for Linux

### DIFF
--- a/INSTRUCTIONS.TXT
+++ b/INSTRUCTIONS.TXT
@@ -32,6 +32,7 @@ script. This is useful for installing additional requirements manually.
 # Using an AMD GPU in Linux
 
 Requires ROCm SDK 5.4.2 to be installed.
+Some systems may also need: sudo apt-get install libstdc++-12-dev
 
 Edit the "webui.py" script using a text editor and un-comment the
 lines near the top of the script if needed for your AMD GPU.

--- a/INSTRUCTIONS.TXT
+++ b/INSTRUCTIONS.TXT
@@ -33,6 +33,5 @@ script. This is useful for installing additional requirements manually.
 
 Requires ROCm SDK 5.4.2 to be installed.
 
-Edit the "webui.py" script using a text editor and un-comment and modify the
-lines near the top of the script according to your setup. In particular, modify
-the os.environ["ROCM_PATH"] = '/opt/rocm' line to point to your ROCm installation.
+Edit the "webui.py" script using a text editor and un-comment the
+lines near the top of the script if needed for your AMD GPU.

--- a/INSTRUCTIONS.TXT
+++ b/INSTRUCTIONS.TXT
@@ -31,6 +31,8 @@ script. This is useful for installing additional requirements manually.
 
 # Using an AMD GPU in Linux
 
+Requires ROCm SDK 5.4.2 to be installed.
+
 Edit the "webui.py" script using a text editor and un-comment and modify the
 lines near the top of the script according to your setup. In particular, modify
 the os.environ["ROCM_PATH"] = '/opt/rocm' line to point to your ROCm installation.

--- a/INSTRUCTIONS.TXT
+++ b/INSTRUCTIONS.TXT
@@ -28,3 +28,9 @@ CMD_FLAGS = '--chat --api'
 
 To run an interactive shell in the miniconda environment, run the "cmd"
 script. This is useful for installing additional requirements manually.
+
+# Using an AMD GPU in Linux
+
+Edit the "webui.py" script using a text editor and un-comment and modify the
+lines near the top of the script according to your setup. In particular, modify
+the os.environ["ROCM_PATH"] = '/opt/rocm' line to point to your ROCm installation.

--- a/INSTRUCTIONS.TXT
+++ b/INSTRUCTIONS.TXT
@@ -34,5 +34,6 @@ script. This is useful for installing additional requirements manually.
 Requires ROCm SDK 5.4.2 to be installed.
 Some systems may also need: sudo apt-get install libstdc++-12-dev
 
-Edit the "webui.py" script using a text editor and un-comment the
-lines near the top of the script if needed for your AMD GPU.
+Edit the "webui.py" script using a text editor and un-comment and modify the
+lines near the top of the script according to your setup. In particular, modify
+the os.environ["ROCM_PATH"] = '/opt/rocm' line to point to your ROCm installation.

--- a/INSTRUCTIONS.TXT
+++ b/INSTRUCTIONS.TXT
@@ -31,7 +31,7 @@ script. This is useful for installing additional requirements manually.
 
 # Using an AMD GPU in Linux
 
-Requires ROCm SDK 5.4.2 to be installed.
+Requires ROCm SDK 5.4.2 or 5.4.3 to be installed.
 Some systems may also need: sudo apt-get install libstdc++-12-dev
 
 Edit the "webui.py" script using a text editor and un-comment and modify the

--- a/webui.py
+++ b/webui.py
@@ -214,9 +214,9 @@ def update_dependencies():
 
     # Install/Update ROCm AutoGPTQ for AMD GPUs
     if '+rocm' in torver:
-        if run_cmd("[ -d ./AutoGPTQ-rocm ] && rm -rfd ./AutoGPTQ-rocm; git clone https://github.com/are-we-gfx1100-yet/AutoGPTQ-rocm.git ./AutoGPTQ-rocm && cp ./AutoGPTQ-rocm/setup_rocm.py ./AutoGPTQ-rocm/setup.py && python -m pip install ./AutoGPTQ-rocm --force-reinstall --no-deps", environment=True).returncode != 0:
+        if run_cmd("[ -d ./AutoGPTQ-rocm ] && rm -rfd ./AutoGPTQ-rocm; git clone https://github.com/jllllll/AutoGPTQ.git ./AutoGPTQ-rocm -b rocm && cp ./AutoGPTQ-rocm/setup_rocm.py ./AutoGPTQ-rocm/setup.py && python -m pip install ./AutoGPTQ-rocm --force-reinstall --no-deps", environment=True).returncode != 0:
             print_big_message("WARNING: AutoGPTQ kernel compilation failed!\n       The installer will proceed to install a pre-compiled wheel.")
-            if run_cmd("python -m pip install https://github.com/jllllll/GPTQ-for-LLaMa-Wheels/raw/Linux-x64/ROCm-5.4.2/auto_gptq-0.3.0.dev0%2Brocm5.4.2-cp310-cp310-linux_x86_64.whl --force-reinstall --no-deps", environment=True).returncode != 0:
+            if run_cmd("python -m pip install https://github.com/jllllll/GPTQ-for-LLaMa-Wheels/raw/Linux-x64/ROCm-5.4.2/auto_gptq-0.3.2%2Brocm5.4.2-cp310-cp310-linux_x86_64.whl --force-reinstall --no-deps", environment=True).returncode != 0:
                 print_big_message("ERROR: AutoGPTQ wheel installation failed!\n       You will not be able to use GPTQ-based models with AutoGPTQ.")
 
     # Install GPTQ-for-LLaMa dependencies

--- a/webui.py
+++ b/webui.py
@@ -212,7 +212,7 @@ def update_dependencies():
         rocm_gptq = run_cmd("python -m pip install https://github.com/jllllll/GPTQ-for-LLaMa-Wheels/raw/Linux-x64/ROCm-5.4.2/quant_cuda-0.0.0-cp310-cp310-linux_x86_64.whl --force-reinstall", environment=True).returncode == 0
         # Install ROCm AutoGPTQ wheel, compile from source if failed to install
         if run_cmd("python -m pip install https://github.com/jllllll/GPTQ-for-LLaMa-Wheels/raw/Linux-x64/ROCm-5.4.2/auto_gptq-0.3.0.dev0%2Brocm5.4.2-cp310-cp310-linux_x86_64.whl --force-reinstall --no-deps", environment=True).returncode != 0:
-            if run_cmd("[ -d ./AutoGPTQ-rocm ] && rm -rfd ./AutoGPTQ-rocm; git clone https://github.com/are-we-gfx1100-yet/AutoGPTQ-rocm.git ./AutoGPTQ-rocm && cp ./AutoGPTQ-rocm/setup_rocm.py ./AutoGPTQ-rocm/setup.py && python -m pip install ./AutoGPTQ-rocm --force-reinstall --no-deps --dry-run", environment=True).returncode != 0:
+            if run_cmd("[ -d ./AutoGPTQ-rocm ] && rm -rfd ./AutoGPTQ-rocm; git clone https://github.com/are-we-gfx1100-yet/AutoGPTQ-rocm.git ./AutoGPTQ-rocm && cp ./AutoGPTQ-rocm/setup_rocm.py ./AutoGPTQ-rocm/setup.py && python -m pip install ./AutoGPTQ-rocm --force-reinstall --no-deps", environment=True).returncode != 0:
                 print_big_message("ERROR: AutoGPTQ kernel compilation failed!\n       You will not be able to use GPTQ-based models with AutoGPTQ.")
 
     # Install GPTQ-for-LLaMa dependencies

--- a/webui.py
+++ b/webui.py
@@ -23,6 +23,7 @@ if "OOBABOOGA_FLAGS" in os.environ:
     
 
 # Remove the '# ' from the following lines if needed for your AMD GPU on Linux
+# os.environ["ROCM_PATH"] = '/opt/rocm'
 # os.environ["HSA_OVERRIDE_GFX_VERSION"] = '10.3.0'
 # os.environ["HCC_AMDGPU_TARGET"] = 'gfx1030'
 
@@ -185,34 +186,14 @@ def update_dependencies():
         os.chdir("exllama")
         run_cmd("git pull", environment=True)
         os.chdir("..")
+        
+    # exllama module does not support AMD GPU
+    if '+rocm' in torver:
+        run_cmd("python -m pip uninstall -y exllama", environment=True)
 
     # Fix build issue with exllama in Linux/WSL
     if sys.platform.startswith("linux") and not os.path.exists(f"{conda_env_path}/lib64"):
         run_cmd(f'ln -s "{conda_env_path}/lib" "{conda_env_path}/lib64"', environment=True)
-        
-    # exllama module does not support AMD GPU   Also check for ROCm version and set needed env vars
-    if '+rocm' in torver:
-        run_cmd("python -m pip uninstall -y exllama", environment=True)
-        if os.path.exists("/opt/rocm-5.4.2/bin/hipcc"):
-            hipcc = run_cmd("/opt/rocm-5.4.2/bin/hipcc --version", environment=True, capture_output=True)
-            if hipcc.returncode == 0:
-                os.environ["ROCM_PATH"] = '/opt/rocm-5.4.2'
-                os.environ["PATH"] = '/opt/rocm-5.4.2:' + os.environ["PATH"]
-            else:
-                print("Failed to check hipcc version!")
-                print(hipcc.stdout.decode('utf-8'))
-                sys.exit()
-        elif os.path.exists("/opt/rocm/bin/hipcc"):
-            hipcc = run_cmd("/opt/rocm/bin/hipcc --version", environment=True, capture_output=True)
-            if hipcc.returncode == 0 and 'HIP version: 5.4.2' in hipcc.decode('utf-8'):
-                os.environ["ROCM_PATH"] = '/opt/rocm'
-                os.environ["PATH"] = '/opt/rocm:' + os.environ["PATH"]
-            else:
-                print_big_message("ROCm 5.4.2 not found!")
-                sys.exit()
-        else:
-            print_big_message("ROCm 5.4.2 not found!")
-            sys.exit()
 
     # Install GPTQ-for-LLaMa which enables 4bit CUDA quantization
     if not os.path.exists("GPTQ-for-LLaMa/"):

--- a/webui.py
+++ b/webui.py
@@ -79,7 +79,7 @@ def install_dependencies():
     print("What is your GPU")
     print()
     print("A) NVIDIA")
-    print("B) AMD (Linux only. Requires ROCm SDK 5.4.2/5.4.3)")
+    print("B) AMD (Linux/MacOS only. Requires ROCm SDK 5.4.2/5.4.3 on Linux)")
     print("C) Apple M Series")
     print("D) None (I want to run in CPU mode)")
     print()
@@ -200,7 +200,7 @@ def update_dependencies():
         # Install oobabooga fork if min compute met or if failed to check
         if '+rocm' in torver:
             run_cmd("git clone https://github.com/WapaMario63/GPTQ-for-LLaMa-ROCm.git GPTQ-for-LLaMa -b rocm", assert_success=True, environment=True)
-        elif and gptq_min_compute_check or compute_array.returncode != 0:
+        elif gptq_min_compute_check or compute_array.returncode != 0:
             run_cmd("git clone https://github.com/oobabooga/GPTQ-for-LLaMa.git -b cuda", assert_success=True, environment=True)
         else:
             run_cmd("git clone https://github.com/qwopqwop200/GPTQ-for-LLaMa.git -b cuda", assert_success=True, environment=True)

--- a/webui.py
+++ b/webui.py
@@ -197,7 +197,10 @@ def update_dependencies():
 
     # Install GPTQ-for-LLaMa which enables 4bit CUDA quantization
     if not os.path.exists("GPTQ-for-LLaMa/"):
-        run_cmd("git clone https://github.com/oobabooga/GPTQ-for-LLaMa.git -b cuda", assert_success=True, environment=True)
+        if '+rocm' in torver:
+            run_cmd("git clone https://github.com/WapaMario63/GPTQ-for-LLaMa-ROCm.git GPTQ-for-LLaMa -b rocm", assert_success=True, environment=True)
+        else:
+            run_cmd("git clone https://github.com/oobabooga/GPTQ-for-LLaMa.git -b cuda", assert_success=True, environment=True)
 
     # Install GPTQ-for-LLaMa dependencies
     os.chdir("GPTQ-for-LLaMa")
@@ -222,7 +225,10 @@ def update_dependencies():
         sys.exit()
 
     # Compile and install GPTQ-for-LLaMa
-    if os.path.exists('setup_cuda.py'):
+    if '+rocm' in torver:
+        if os.path.exists('setup_rocm.py'):
+            os.rename("setup_rocm.py", "setup.py")
+    elif os.path.exists('setup_cuda.py'):
         os.rename("setup_cuda.py", "setup.py")
 
     run_cmd("python -m pip install .", environment=True)


### PR DESCRIPTION
Requires the ROCm SDK version 5.4.2 or 5.4.3. I do not have an AMD GPU, so community testing will be needed.

Things added:
- Install ROCm version of Pytorch
- Install ROCm ExLlama module for AMD GPUs
- Use a ROCm-compatible fork of GPTQ-for-LLaMa
  - [Source](https://github.com/WapaMario63/GPTQ-for-LLaMa-ROCm)
  - Pre-compiled wheel is used if failed to build locally.
- Use a ROCm-compatible fork of AutoGPTQ on AMD GPUs with pre-compiled wheel
  - [Source](https://github.com/jllllll/AutoGPTQ/tree/rocm) based on: [AutoGPTQ-rocm](https://github.com/are-we-gfx1100-yet/AutoGPTQ-rocm)
  - Pre-compiled wheel is used if failed to build locally. This should hopefully improve compatibility.
- Add AMD GPU installation instructions to INSTRUCTIONS.TXT