### PR TITLE
Support non standard shells on Linux

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -51,7 +51,7 @@ def run_cmd(cmd, assert_success=False, environment=False, capture_output=False, 
             cmd = ". \"" + conda_sh_path + "\" && conda activate \"" + conda_env_path + "\" && " + cmd
 
     # Run shell commands
-    result = subprocess.run(cmd, shell=True, capture_output=capture_output, env=env)
+    result = subprocess.run(cmd, shell=True, capture_output=capture_output, env=env, executable="/bin/bash")
 
     # Assert the command ran successfully
     if assert_success and result.returncode != 0:


### PR DESCRIPTION
If you're not using bash on Linux, there would be problems when the script tried to run commands. This specifies that python should use bash to run commands.

As far as I can tell from the documentation, this shouldn't effect Windows:
> If shell=True, on POSIX the executable argument specifies a replacement shell for the default /bin/sh.

I haven't tested this though.