### PR TITLE
Add CMD_FLAGS.txt functionality to WSL installer

### DIFF
--- a/generate_zips.sh
+++ b/generate_zips.sh
@@ -1,6 +1,6 @@
 mkdir oobabooga_{windows,linux,macos,wsl}
 for p in windows macos linux wsl; do
-  if [ "$p" == "wsl" ]; then cp {*$p*\.*,webui.py,INSTRUCTIONS-WSL.txt} oobabooga_$p;
+  if [ "$p" == "wsl" ]; then cp {*$p*\.*,webui.py,INSTRUCTIONS-WSL.txt,CMD_FLAGS.txt} oobabooga_$p;
   else cp {*$p*\.*,webui.py,INSTRUCTIONS.txt,CMD_FLAGS.txt} oobabooga_$p; fi
   zip -r oobabooga_$p.zip oobabooga_$p;
 done

--- a/wsl.sh
+++ b/wsl.sh
@@ -46,6 +46,7 @@ if [[ "$INSTALL_DIR" =~ " " ]]; then echo This script relies on Miniconda which 
 # create install dir if missing and copy webui.py to install dir to maintain functionality without edit
 if [ ! -d "$INSTALL_DIR" ]; then mkdir -p "$INSTALL_DIR" || exit; fi
 cp -u "./webui.py" "$INSTALL_DIR"
+if [ -f "./CMD_FLAGS.txt" ]; then cp -u "./CMD_FLAGS.txt" "$INSTALL_DIR"; fi
 
 # figure out whether git and conda needs to be installed
 if "$CONDA_ROOT_PREFIX/bin/conda" --version &>/dev/null; then conda_exists="T"; fi


### PR DESCRIPTION
Similar to how `webui.py` is handled, `CMD_FLAGS.txt` will be copied to the WSL installation directory.
The file can be edited in Windows and changes will be carried over. Changes to the file in WSL will be maintained until the Windows copy is changed.