### PR TITLE
feature: allow comments in CMD_FLAGS.txt

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -18,9 +18,9 @@ else:
     if os.path.exists(cmd_flags_path):
         with open(cmd_flags_path, 'r') as f:
             CMD_FLAGS = ' '.join(line.strip() for line in f.read().splitlines() if line.strip() and not line.strip().startswith('#'))
-    if CMD_FLAGS:
-        print("The following flags have been taken from the file 'CMD_FLAGS.txt':")
-        print(CMD_FLAGS)
+        if CMD_FLAGS:
+            print("The following flags have been taken from the file 'CMD_FLAGS.txt':")
+            print(CMD_FLAGS)
     else:
         CMD_FLAGS = ''
 

--- a/webui.py
+++ b/webui.py
@@ -18,9 +18,6 @@ else:
     if os.path.exists(cmd_flags_path):
         with open(cmd_flags_path, 'r') as f:
             CMD_FLAGS = ' '.join(line.strip() for line in f if line.strip() and not line.strip().startswith('#'))
-        if CMD_FLAGS:
-            print("The following flags have been taken from the file 'CMD_FLAGS.txt':")
-            print(CMD_FLAGS)
     else:
         CMD_FLAGS = ''
 

--- a/webui.py
+++ b/webui.py
@@ -17,7 +17,7 @@ else:
     cmd_flags_path = os.path.join(script_dir, "CMD_FLAGS.txt")
     if os.path.exists(cmd_flags_path):
         with open(cmd_flags_path, 'r') as f:
-            CMD_FLAGS = ' '.join(line.strip() for line in f.read().splitlines() if line.strip() and not line.strip().startswith('#'))
+            CMD_FLAGS = ' '.join(line.strip() for line in f if line.strip() and not line.strip().startswith('#'))
         if CMD_FLAGS:
             print("The following flags have been taken from the file 'CMD_FLAGS.txt':")
             print(CMD_FLAGS)

--- a/webui.py
+++ b/webui.py
@@ -17,7 +17,10 @@ else:
     cmd_flags_path = os.path.join(script_dir, "CMD_FLAGS.txt")
     if os.path.exists(cmd_flags_path):
         with open(cmd_flags_path, 'r') as f:
-            CMD_FLAGS = ' '.join(line.strip() for line in f.read().splitlines() if line.strip())
+            CMD_FLAGS = ' '.join(line.strip() for line in f.read().splitlines() if line.strip() and not line.strip().startswith('#'))
+    if CMD_FLAGS:
+        print("The following flags have been taken from the file 'CMD_FLAGS.txt':")
+        print(CMD_FLAGS)
     else:
         CMD_FLAGS = ''
 


### PR DESCRIPTION
Allow comments in CMD_FLAGS.txt to allow things like this (blushing, yes this is my CMD_FLAGS.txt)

```
--api
--model=TheBloke_OpenOrca-Platypus2-13B-GPTQ_gptq-8bit-128g-actorder_True
--listen
--extensions dbh superbooga

# Other flags I use frequently
# ---------------------------------
# --trust-remote-code
#  --notebook 

# Models - the good, the bad, and the ugly
# -----------------------------------------------------------------------------
# Wow - good stuff - uncensored, pretty fast, good with patient evaluations...
# --model=TheBloke_MythoLogic-L2-13B-GPTQ_gptq-8bit-64g-actorder_True
# --model=TheBloke_vicuna-13B-v1.5-16K-GPTQ_gptq-8bit-128g-actorder_True
# --model=TheBloke_guanaco-13B-SuperHOT-8K-GPTQ' # needs trust_remote_code
# Uncensored AF - word association machine
# --model=TheBloke_Llama-2-13B-GPTQ_gptq-8bit-64g-actorder_True
```
